### PR TITLE
add method to manage alias

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
 	<groupId>io.gravitee.elasticsearch</groupId>
 	<artifactId>gravitee-common-elasticsearch</artifactId>
-	<version>3.8.4</version>
+	<version>3.8.5</version>
 
 	<name>Gravitee.io APIM - Elasticsearch - Common</name>
 

--- a/src/main/java/io/gravitee/elasticsearch/client/Client.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/Client.java
@@ -23,9 +23,9 @@ import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.elasticsearch.model.bulk.BulkResponse;
 import io.gravitee.elasticsearch.version.ElasticsearchInfo;
 import io.reactivex.Completable;
+import io.reactivex.Maybe;
 import io.reactivex.Single;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.json.Json;
 import java.util.List;
 
 /**
@@ -41,6 +41,6 @@ public interface Client {
     Single<SearchResponse> search(String indexes, String type, String query);
     Single<CountResponse> count(String indexes, String type, String query);
 
-    Single<JsonNode> getAlias(String aliasName);
-    Completable createIndexAndAlias(String indexName, String aliasName);
+    Maybe<JsonNode> getAlias(String aliasName);
+    Completable createIndexWithAlias(String indexName, String template);
 }

--- a/src/main/java/io/gravitee/elasticsearch/client/Client.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/Client.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.elasticsearch.client;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.elasticsearch.exception.ElasticsearchException;
 import io.gravitee.elasticsearch.model.CountResponse;
 import io.gravitee.elasticsearch.model.Health;
@@ -24,6 +25,7 @@ import io.gravitee.elasticsearch.version.ElasticsearchInfo;
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.Json;
 import java.util.List;
 
 /**
@@ -38,4 +40,7 @@ public interface Client {
     Completable putPipeline(String templateName, String template);
     Single<SearchResponse> search(String indexes, String type, String query);
     Single<CountResponse> count(String indexes, String type, String query);
+
+    Single<JsonNode> getAlias(String aliasName);
+    Completable createIndexAndAlias(String indexName, String aliasName);
 }

--- a/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.elasticsearch.client;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.elasticsearch.client.http.HttpClient;
 import io.gravitee.elasticsearch.client.http.HttpClientConfiguration;
 import io.gravitee.elasticsearch.config.Endpoint;
@@ -82,6 +83,22 @@ public class HttpClientTest {
         observer.assertNoErrors();
         observer.assertComplete();
         observer.assertValue(health1 -> "gravitee_test".equals(health1.getClusterName()));
+    }
+
+    @Test
+    public void shouldGetAlias() throws InterruptedException, ExecutionException, IOException {
+        String expectedAlias = "{\"gravitee_test\":{\"aliases\":{\"gravitee_test_alias\":{}}}}";
+
+        Single<JsonNode> alias = client
+            .createIndexAndAlias("gravitee_test", "gravitee_test_alias")
+            .andThen(client.getAlias("gravitee_test_alias"));
+
+        TestObserver<JsonNode> observer = alias.test();
+        observer.awaitTerminalEvent();
+
+        observer.assertNoErrors();
+        observer.assertComplete();
+        observer.assertValue(node -> expectedAlias.equals(node.toString()));
     }
 
     /*


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7110

**Description**

add method to manage alias
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.8.5-7110-fix-ILM-support-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/3.8.5-7110-fix-ILM-support-SNAPSHOT/gravitee-common-elasticsearch-3.8.5-7110-fix-ILM-support-SNAPSHOT.zip)
  <!-- Version placeholder end -->
