### PR TITLE
merge 3.8.5 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## [3.8.5](https://github.com/gravitee-io/gravitee-common-elasticsearch/compare/3.8.4...3.8.5) (2022-05-17)
+
+
+### Bug Fixes
+
+* add method to manage alias ([51c0fa4](https://github.com/gravitee-io/gravitee-common-elasticsearch/commit/51c0fa437570b9d4b19ee6610b62bc67c03b43de)), closes [gravitee-io/issues#7110](https://github.com/gravitee-io/issues/issues/7110)
+* add modification regarding PR feedbacks ([fc2bdd3](https://github.com/gravitee-io/gravitee-common-elasticsearch/commit/fc2bdd3e0e50816759b4a055a60401a97b18f934))

--- a/src/main/java/io/gravitee/elasticsearch/client/Client.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/Client.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.elasticsearch.client;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.elasticsearch.exception.ElasticsearchException;
 import io.gravitee.elasticsearch.model.CountResponse;
 import io.gravitee.elasticsearch.model.Health;
@@ -22,6 +23,7 @@ import io.gravitee.elasticsearch.model.SearchResponse;
 import io.gravitee.elasticsearch.model.bulk.BulkResponse;
 import io.gravitee.elasticsearch.version.ElasticsearchInfo;
 import io.reactivex.Completable;
+import io.reactivex.Maybe;
 import io.reactivex.Single;
 import io.vertx.core.buffer.Buffer;
 import java.util.List;
@@ -38,4 +40,7 @@ public interface Client {
     Completable putPipeline(String templateName, String template);
     Single<SearchResponse> search(String indexes, String type, String query);
     Single<CountResponse> count(String indexes, String type, String query);
+
+    Maybe<JsonNode> getAlias(String aliasName);
+    Completable createIndexWithAlias(String indexName, String template);
 }

--- a/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
@@ -15,18 +15,21 @@
  */
 package io.gravitee.elasticsearch.client;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.elasticsearch.client.http.HttpClient;
 import io.gravitee.elasticsearch.client.http.HttpClientConfiguration;
 import io.gravitee.elasticsearch.config.Endpoint;
 import io.gravitee.elasticsearch.embedded.ElasticsearchNode;
 import io.gravitee.elasticsearch.model.Health;
 import io.gravitee.elasticsearch.version.ElasticsearchInfo;
+import io.reactivex.Maybe;
 import io.reactivex.Single;
 import io.reactivex.observers.TestObserver;
 import io.vertx.reactivex.core.Vertx;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,6 +85,33 @@ public class HttpClientTest {
         observer.assertNoErrors();
         observer.assertComplete();
         observer.assertValue(health1 -> "gravitee_test".equals(health1.getClusterName()));
+    }
+
+    @Test
+    public void shouldGetAlias() {
+        String template = "{\"aliases\":{\"gravitee_test_alias\":{\"is_write_index\": true}}}";
+        String expectedAlias = "{\"gravitee_test\":{\"aliases\":{\"gravitee_test_alias\":{}}}}";
+
+        Maybe<JsonNode> alias = client.createIndexWithAlias("gravitee_test", template).andThen(client.getAlias("gravitee_test_alias"));
+
+        TestObserver<JsonNode> observer = alias.test();
+        observer.awaitTerminalEvent();
+
+        observer.assertNoErrors();
+        observer.assertComplete();
+        observer.assertValue(node -> expectedAlias.equals(node.toString()));
+    }
+
+    @Test
+    public void shouldNotGetAlias() {
+        Maybe<JsonNode> alias = client.getAlias("gravitee_test_alias");
+
+        TestObserver<JsonNode> observer = alias.test();
+        observer.awaitTerminalEvent();
+
+        observer.assertNoErrors();
+        observer.assertComplete();
+        observer.assertNoValues();
     }
 
     /*


### PR DESCRIPTION
**Issue**

N/A

**Description**

Merge 3.8.5 into master
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.12.1-merge-master-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/3.12.1-merge-master-SNAPSHOT/gravitee-common-elasticsearch-3.12.1-merge-master-SNAPSHOT.zip)
  <!-- Version placeholder end -->
