### PR TITLE
test: move to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,28 +128,30 @@
 
         <!-- Unit Tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
-
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>elasticsearch</artifactId>

--- a/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
@@ -25,24 +25,22 @@ import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.vertx.rxjava3.core.Vertx;
-import java.io.IOException;
 import java.util.Collections;
-import java.util.concurrent.ExecutionException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { HttpClientTest.TestConfig.class })
 public class HttpClientTest {
 
@@ -57,7 +55,7 @@ public class HttpClientTest {
     private Client client;
 
     @Test
-    public void shouldGetVersion() throws InterruptedException, ExecutionException, IOException {
+    public void shouldGetVersion() throws InterruptedException {
         Single<ElasticsearchInfo> info = client.getInfo();
 
         TestObserver<ElasticsearchInfo> observer = info.test();

--- a/src/test/java/io/gravitee/elasticsearch/index/ILMIndexNameGeneratorTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/index/ILMIndexNameGeneratorTest.java
@@ -15,9 +15,10 @@
  */
 package io.gravitee.elasticsearch.index;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.gravitee.elasticsearch.utils.Type;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -30,12 +31,12 @@ public class ILMIndexNameGeneratorTest {
     @Test
     public void shouldGenerateIndexName() {
         String indexName = generator.getIndexName(Type.REQUEST, 0, 0, null);
-        Assert.assertEquals("gravitee-request", indexName);
+        assertThat(indexName).isEqualTo("gravitee-request");
     }
 
     @Test
     public void shouldGenerateIndexName_withClusters() {
         String indexName = generator.getIndexName(Type.REQUEST, 0, 0, new String[] { "europe", "asia" });
-        Assert.assertEquals("europe:gravitee-request,asia:gravitee-request", indexName);
+        assertThat(indexName).isEqualTo("europe:gravitee-request,asia:gravitee-request");
     }
 }

--- a/src/test/java/io/gravitee/elasticsearch/templating/freemarker/FreeMarkerComponentTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/templating/freemarker/FreeMarkerComponentTest.java
@@ -15,14 +15,13 @@
  */
 package io.gravitee.elasticsearch.templating.freemarker;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the template.
@@ -31,29 +30,27 @@ import org.mockito.junit.MockitoJUnitRunner;
  * @author Sebastien Devaux
  *
  */
-@RunWith(MockitoJUnitRunner.class)
 public class FreeMarkerComponentTest {
 
-    private FreeMarkerComponent freeMarkerComponent = new FreeMarkerComponent();
+    FreeMarkerComponent freeMarkerComponent = new FreeMarkerComponent();
 
-    @Before
-    public void init() throws IOException {
+    @BeforeEach
+    void init() throws IOException {
         freeMarkerComponent.afterPropertiesSet();
     }
 
     @Test
-    public void testGenerateFromTemplateWithoutData() {
-        Assert.assertNotNull(this.freeMarkerComponent);
+    void testGenerateFromTemplateWithoutData() {
         final String result = this.freeMarkerComponent.generateFromTemplate("template.ftl");
-        Assert.assertEquals("test", result);
+        assertThat(result).isEqualTo("test");
     }
 
     @Test
-    public void testGenerateFromTemplateWithData() {
+    void testGenerateFromTemplateWithData() {
         final Map<String, Object> data = new HashMap<>();
         data.put("data", "test");
 
         final String result = this.freeMarkerComponent.generateFromTemplate("templateWithData.ftl", data);
-        Assert.assertEquals("test with data : test", result);
+        assertThat(result).isEqualTo("test with data : test");
     }
 }

--- a/src/test/java/io/gravitee/elasticsearch/utils/DateUtilsTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/utils/DateUtilsTest.java
@@ -15,9 +15,10 @@
  */
 package io.gravitee.elasticsearch.utils;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -26,14 +27,14 @@ import org.junit.Test;
 public class DateUtilsTest {
 
     @Test
-    public void shouldReturnSingleDate() {
-        List<String> indices = DateUtils.rangedIndices(1474581851724l, 1474582151724l);
-        Assert.assertEquals(1, indices.size());
+    void shouldReturnSingleDate() {
+        List<String> indices = DateUtils.rangedIndices(1474581851724L, 1474582151724L);
+        assertThat(indices).hasSize(1);
     }
 
     @Test
-    public void shouldReturnMultipleDate() {
-        List<String> indices = DateUtils.rangedIndices(1473459236000l, 1474582436000l);
-        Assert.assertEquals(14, indices.size());
+    void shouldReturnMultipleDate() {
+        List<String> indices = DateUtils.rangedIndices(1473459236000L, 1474582436000L);
+        assertThat(indices).hasSize(14);
     }
 }


### PR DESCRIPTION
**Description**

Migrate tests to JUnit 5
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-move-to-junit5-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/4.1.0-move-to-junit5-SNAPSHOT/gravitee-common-elasticsearch-4.1.0-move-to-junit5-SNAPSHOT.zip)
  <!-- Version placeholder end -->
