### PR TITLE
Add ES 8 support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,10 +13,11 @@ An example can be found https://github.com/gravitee-io/gravitee-repoter-elastics
 
 
 == Testing
-By default, unit tests are run with a TestContainer version of ElasticSearch 7.17.7, but sometimes it can be useful to run them against other version of ElasticSearch.
+By default, unit tests are run with a TestContainer version of ElasticSearch 8.5.2, but sometimes it can be useful to run them against other version of ElasticSearch.
 To do so you can use the following commands:
 
 * ES 5.x: `mvn clean test -Delasticsearch.version=5.6.16`
 * ES 6.x: `mvn clean test -Delasticsearch.version=6.8.23`
-* ES 7.x: `mvn clean test -Delasticsearch.version=7.17.7` (Default)
+* ES 7.x: `mvn clean test -Delasticsearch.version=7.17.7`
+* ES 8.x: `mvn clean test -Delasticsearch.version=8.5.2` (Default)
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>io.gravitee.elasticsearch</groupId>
     <artifactId>gravitee-common-elasticsearch</artifactId>
-    <version>4.1.0-alpha.7</version>
+    <version>4.1.0-es8-support-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Elasticsearch - Common</name>
 

--- a/src/main/java/io/gravitee/elasticsearch/utils/Type.java
+++ b/src/main/java/io/gravitee/elasticsearch/utils/Type.java
@@ -27,10 +27,7 @@ public enum Type {
     V4_LOG("v4-log"),
     V4_METRICS("v4-metrics"),
     V4_MESSAGE_METRICS("v4-message-metrics"),
-    V4_MESSAGE_LOG("v4-message-log"),
-
-    // For ES7 support
-    DOC("_doc");
+    V4_MESSAGE_LOG("v4-message-log");
 
     private final String type;
 

--- a/src/main/java/io/gravitee/elasticsearch/version/Version.java
+++ b/src/main/java/io/gravitee/elasticsearch/version/Version.java
@@ -83,4 +83,9 @@ public class Version {
         // from ES version 6, we can use ILM managed indexes, which names are not suffixed by date
         return isOpenSearch() || getMajorVersion() >= 6;
     }
+
+    public boolean canUseDateHistogramFixedInterval() {
+        // in ES version 7, time interval in dateHistogram aggregation is deprecated and removed in ES 8. Instead, we have to use fixed_interval
+        return !isOpenSearch() && getMajorVersion() >= 7;
+    }
 }

--- a/src/main/resources/freemarker/es8x/alias/alias.ftl
+++ b/src/main/resources/freemarker/es8x/alias/alias.ftl
@@ -1,0 +1,9 @@
+<@compress single_line=true>
+{
+    "aliases": {
+        "${aliasName}": {
+            "is_write_index": true
+        }
+    }
+}
+</@compress>

--- a/src/main/resources/freemarker/es8x/index/health.ftl
+++ b/src/main/resources/freemarker/es8x/index/health.ftl
@@ -1,0 +1,66 @@
+<#ftl output_format="JSON">
+<#macro stringOrNull data="">
+    <#if data != "">
+    "${data}"<#else>
+    null</#if>
+</#macro>
+{ "index" : { "_index" : "${index}", "_id" : "${status.getId()}" } }
+<@compress single_line=true>
+{
+    "gateway":"${gateway}",
+    "api":"${status.getApi()}",
+    "endpoint":"${status.getEndpoint()}",
+    "available":${status.isAvailable()?c},
+    "response-time":${status.getResponseTime()},
+    "success":${status.isSuccess()?c},
+    "state":${status.getState()},
+    "transition":${status.isTransition()?c},
+    "steps": [
+<#list status.getSteps() as step>
+        {"name": "${step.getName()}",
+        "success":${step.isSuccess()?c},
+        "request": {
+            "uri":"${step.getRequest().getUri()}",
+            "method":"${step.getRequest().getMethod()}"
+            <#if step.getRequest().getBody()??>
+            ,"body":"${step.getRequest().getBody()?j_string}"
+            </#if>
+            <#if step.getRequest().getHeaders()??>
+            ,"headers":{
+                <#list step.getRequest().getHeaders() as headerKey, headerValue>
+                    "${headerKey}": [
+                    <#list headerValue as value>
+                        "${value?j_string}"
+                        <#sep>,</#sep>
+                    </#list>
+                    ]
+                    <#sep>,</#sep>
+                </#list>
+            }
+            </#if>
+        },
+        "response": {
+            "status":${step.getResponse().getStatus()}
+            <#if step.getResponse().getBody()??>
+            ,"body":"${step.getResponse().getBody()?j_string}"
+            </#if>
+            <#if step.getResponse().getHeaders()??>
+            ,"headers":{
+                <#list step.getResponse().getHeaders() as headerKey, headerValue>
+                    "${headerKey}": [
+                    <#list headerValue as value>
+                        "${value?j_string}"
+                        <#sep>,</#sep>
+                    </#list>
+                    ]
+                    <#sep>,</#sep>
+                </#list>
+            }
+            </#if>
+        },
+        "response-time":${step.getResponseTime()},
+        "message":<@stringOrNull data=step.getMessage()/>
+    }<#sep>,</#sep>
+</#list>],
+"@timestamp":"${@timestamp}"
+}</@compress>

--- a/src/main/resources/freemarker/es8x/index/log.ftl
+++ b/src/main/resources/freemarker/es8x/index/log.ftl
@@ -1,0 +1,98 @@
+{ "index" : { "_index" : "${index}", "_id" : "${log.getRequestId()}" } }
+<@compress single_line=true>
+{
+  "@timestamp":"${@timestamp}",
+  "api":"${log.getApi()}"
+  <#if log.getClientRequest()??>
+  ,"client-request": {
+  "method":"${log.getClientRequest().getMethod()}",
+  "uri":"${log.getClientRequest().getUri()}"
+    <#if log.getClientRequest().getBody()??>
+    ,"body":"${log.getClientRequest().getBody()?j_string}"
+    </#if>
+    <#if log.getClientRequest().getHeaders()??>
+    ,"headers":{
+      <#list log.getClientRequest().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
+          <#if value??>
+            "${value?j_string}"
+            <#sep>,</#sep>
+          </#if>
+        </#list>
+      ]
+        <#sep>,</#sep>
+      </#list>
+    }
+    </#if>
+  }
+  ,"client-response": {
+  "status":${log.getClientResponse().getStatus()}
+    <#if log.getClientResponse().getBody()??>
+    ,"body":"${log.getClientResponse().getBody()?j_string}"
+    </#if>
+    <#if log.getClientResponse().getHeaders()??>
+    ,"headers":{
+      <#list log.getClientResponse().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
+          <#if value??>
+            "${value?j_string}"
+            <#sep>,</#sep>
+          </#if>
+        </#list>
+      ]
+        <#sep>,</#sep>
+      </#list>
+    }
+    </#if>
+  }
+  </#if>
+  <#if log.getProxyRequest()??>
+  ,"proxy-request": {
+  "method":"${log.getProxyRequest().getMethod()}",
+  "uri":"${log.getProxyRequest().getUri()}"
+    <#if log.getProxyRequest().getBody()??>
+    ,"body":"${log.getProxyRequest().getBody()?j_string}"
+    </#if>
+    <#if log.getProxyRequest().getHeaders()??>
+    ,"headers":{
+      <#list log.getProxyRequest().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
+          <#if value??>
+          "${value?j_string}"
+            <#sep>,</#sep>
+          </#if>
+        </#list>
+      ]
+        <#sep>,</#sep>
+      </#list>
+    }
+    </#if>
+  }
+  </#if>
+  <#if log.getProxyResponse()??>
+  ,"proxy-response": {
+  "status":${log.getProxyResponse().getStatus()}
+    <#if log.getProxyResponse().getBody()??>
+    ,"body":"${log.getProxyResponse().getBody()?j_string}"
+    </#if>
+    <#if log.getProxyResponse().getHeaders()??>
+    ,"headers":{
+      <#list log.getProxyResponse().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
+          <#if value??>
+          "${value?j_string}"
+            <#sep>,</#sep>
+          </#if>
+        </#list>
+      ]
+        <#sep>,</#sep>
+      </#list>
+    }
+    </#if>
+  }
+  </#if>
+}</@compress>

--- a/src/main/resources/freemarker/es8x/index/monitor.ftl
+++ b/src/main/resources/freemarker/es8x/index/monitor.ftl
@@ -1,0 +1,72 @@
+{ "index" : { "_index" : "${index}" } }
+<@compress single_line=true>
+{
+  "os":{
+    "cpu":{
+      "percent":${percent},
+      "load_average":{
+        <#if load_average_1m??>"1m":${load_average_1m}</#if>
+        <#if load_average_5m??>,"5m":${load_average_5m}</#if>
+        <#if load_average_15m??>,"15m":${load_average_15m}</#if>
+      }
+    },
+    "mem":{
+      "total_in_bytes":${mem_total_in_bytes},
+      "free_in_bytes":${mem_free_in_bytes},
+      "used_in_bytes":${mem_used_in_bytes},
+      "free_percent":${mem_free_percent},
+      "used_percent":${mem_used_percent}
+    }
+  },
+  "process":{
+    "timestamp":${process_timestamp},
+    "open_file_descriptors":${open_file_descriptors},
+    "max_file_descriptors":${max_file_descriptors},
+    "cpu":{
+        "percent":${process_percent}
+    }
+  },
+  "jvm":{
+    "timestamp":${jvm_timestamp},
+    "uptime_in_millis":${uptime_in_millis},
+    "mem":{
+      "heap_used_in_bytes":${heap_used_in_bytes},
+      "heap_used_percent":${heap_used_percent},
+      "heap_committed_in_bytes":${heap_committed_in_bytes},
+      "heap_max_in_bytes":${heap_max_in_bytes},
+      "non_heap_used_in_bytes":${non_heap_used_in_bytes},
+      "non_heap_committed_in_bytes":${non_heap_committed_in_bytes},
+      "pools":{
+<#list pools as pool>
+      "${pool.getName()}":{
+          "used_in_bytes":${pool.getUsed()},
+          "max_in_bytes":${pool.getMax()},
+          "peak_used_in_bytes":${pool.getPeakUsed()},
+          "peak_max_in_bytes":${pool.getPeakMax()}
+        }
+  <#sep>,</#sep>
+</#list>
+      }
+    },
+    "threads":{
+      "count":${count},
+      "peak_count":${peak_count}
+    },
+    "gc":{
+      "collectors":{
+
+<#list collectors as collector>
+        "${collector.getName()}":{
+          "collection_count":${collector.getCollectionCount()},
+          "collection_time_in_millis":${collector.getCollectionTime()}
+        }
+  <#sep>,</#sep>
+</#list>
+
+      }
+    }
+  },
+  "gateway":"${gateway}",
+  "hostname":"${hostname}",
+  "@timestamp":"${@timestamp}"
+}</@compress>

--- a/src/main/resources/freemarker/es8x/index/request.ftl
+++ b/src/main/resources/freemarker/es8x/index/request.ftl
@@ -1,0 +1,82 @@
+{ "index" : { "_index" : "${index}", "_id" : "${metrics.getRequestId()}"<#if pipeline??>, "pipeline" : "${pipeline}"</#if>} }
+<@compress single_line=true>
+{
+  "gateway":"${gateway}"
+  ,"@timestamp":"${@timestamp}"
+  ,"transaction":"${metrics.getTransactionId()}"
+  ,"method":${metrics.getHttpMethod().code()?c}
+  ,"uri":"${metrics.getUri()}"
+  ,"status":${metrics.getStatus()}
+  ,"response-time":${metrics.getProxyResponseTimeMs()}
+  <#if apiResponseTime??>
+    ,"api-response-time":${apiResponseTime}
+  </#if>
+  <#if proxyLatency??>
+  ,"proxy-latency":${proxyLatency}
+  </#if>
+  <#if requestContentLength??>
+  ,"request-content-length":${requestContentLength}
+  </#if>
+  <#if responseContentLength??>
+  ,"response-content-length":${responseContentLength}
+  </#if>
+  <#if metrics.getPlan()??>
+  ,"plan":"${metrics.getPlan()}"
+  </#if>
+  <#if metrics.getApi()??>
+  ,"api":"${metrics.getApi()}"
+  </#if>
+  <#if metrics.getApplication()??>
+  ,"application":"${metrics.getApplication()}"
+  </#if>
+  ,"local-address":"${metrics.getLocalAddress()}"
+  ,"remote-address":"${metrics.getRemoteAddress()}"
+  <#if metrics.getEndpoint()??>
+  ,"endpoint":"${metrics.getEndpoint()}"
+  </#if>
+  <#if metrics.getTenant()??>
+  ,"tenant":"${metrics.getTenant()}"
+  </#if>
+  <#if metrics.getMessage()??>
+  ,"message":"${metrics.getMessage()?j_string}"
+  </#if>
+  <#if metrics.getPath()??>
+  ,"path":"${metrics.getPath()}"
+  </#if>
+  <#if metrics.getMappedPath()??>
+  ,"mapped-path":"${metrics.getMappedPath()}"
+  </#if>
+  <#if metrics.getHost()??>
+  ,"host":"${metrics.getHost()}"
+  </#if>
+  <#if metrics.getUserAgent()?? && pipeline?has_content>
+  ,"user-agent":"${metrics.getUserAgent()?j_string}"
+  <#else>
+  ,"user-agent":""
+  </#if>
+  <#if metrics.getUser()??>
+  ,"user":"${metrics.getUser()}"
+  </#if>
+  <#if metrics.getSecurityType()??>
+  ,"security-type":"${metrics.getSecurityType()}"
+  </#if>
+  <#if metrics.getSecurityToken()??>
+  ,"security-token":"${metrics.getSecurityToken()}"
+  </#if>
+  <#if metrics.getErrorKey()??>
+  ,"error-key":"${metrics.getErrorKey()}"
+  </#if>
+  <#if metrics.getSubscription()??>
+  ,"subscription":"${metrics.getSubscription()}"
+  </#if>
+  <#if metrics.getZone()??>
+  ,"zone":"${metrics.getZone()}"
+  </#if>
+  <#if metrics.getCustomMetrics()??>
+    ,"custom": {
+    <#list metrics.getCustomMetrics() as propKey, propValue>
+      "${propKey}":"${propValue}"<#sep>,
+    </#list>
+    }
+  </#if>
+}</@compress>

--- a/src/main/resources/freemarker/es8x/index/v4-log.ftl
+++ b/src/main/resources/freemarker/es8x/index/v4-log.ftl
@@ -1,0 +1,107 @@
+<#-- @ftlvariable name="index" type="java.lang.String" -->
+<#-- @ftlvariable name="@timestamp" type="java.lang.String" -->
+<#-- @ftlvariable name="log" type="io.gravitee.reporter.api.v4.log.Log" -->
+
+{ "index" : { "_index" : "${index}", "_id" : "${log.getRequestId()}" } }
+<@compress single_line=true>
+{
+  "@timestamp":"${@timestamp}"
+  ,"api-id":"${log.getApiId()}"
+  ,"request-id":"${log.getRequestId()}"
+  ,"client-identifier":"${log.getClientIdentifier()}"
+  ,"request-ended":"${log.isRequestEnded()?c}"
+  <#if log.getEntrypointRequest()??>
+  ,"entrypoint-request": {
+  "method":"${log.getEntrypointRequest().getMethod()}",
+  "uri":"${log.getEntrypointRequest().getUri()}"
+    <#if log.getEntrypointRequest().getBody()??>
+    ,"body":"${log.getEntrypointRequest().getBody()?j_string}"
+    </#if>
+    <#if log.getEntrypointRequest().getHeaders()??>
+    ,"headers":{
+      <#list log.getEntrypointRequest().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
+          <#if value??>
+            "${value?j_string}"
+            <#sep>,</#sep>
+          </#if>
+        </#list>
+      ]
+        <#sep>,</#sep>
+      </#list>
+    }
+    </#if>
+  }
+  </#if>
+  <#if log.getEntrypointResponse()??>
+  ,"entrypoint-response": {
+  "status":${log.getEntrypointResponse().getStatus()}
+    <#if log.getEntrypointResponse().getBody()??>
+    ,"body":"${log.getEntrypointResponse().getBody()?j_string}"
+    </#if>
+    <#if log.getEntrypointResponse().getHeaders()??>
+    ,"headers":{
+      <#list log.getEntrypointResponse().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
+          <#if value??>
+            "${value?j_string}"
+            <#sep>,</#sep>
+          </#if>
+        </#list>
+      ]
+        <#sep>,</#sep>
+      </#list>
+    }
+    </#if>
+  }
+  </#if>
+  <#if log.getEndpointRequest()??>
+  ,"endpoint-request": {
+  "method":"${log.getEndpointRequest().getMethod()}",
+  "uri":"${log.getEndpointRequest().getUri()}"
+    <#if log.getEndpointRequest().getBody()??>
+    ,"body":"${log.getEndpointRequest().getBody()?j_string}"
+    </#if>
+    <#if log.getEndpointRequest().getHeaders()??>
+    ,"headers":{
+      <#list log.getEndpointRequest().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
+          <#if value??>
+          "${value?j_string}"
+            <#sep>,</#sep>
+          </#if>
+        </#list>
+      ]
+        <#sep>,</#sep>
+      </#list>
+    }
+    </#if>
+  }
+  </#if>
+  <#if log.getEndpointResponse()??>
+  ,"endpoint-response": {
+  "status":${log.getEndpointResponse().getStatus()}
+    <#if log.getEndpointResponse().getBody()??>
+    ,"body":"${log.getEndpointResponse().getBody()?j_string}"
+    </#if>
+    <#if log.getEndpointResponse().getHeaders()??>
+    ,"headers":{
+      <#list log.getEndpointResponse().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
+          <#if value??>
+          "${value?j_string}"
+            <#sep>,</#sep>
+          </#if>
+        </#list>
+      ]
+        <#sep>,</#sep>
+      </#list>
+    }
+    </#if>
+  }
+  </#if>
+}</@compress>

--- a/src/main/resources/freemarker/es8x/index/v4-message-log.ftl
+++ b/src/main/resources/freemarker/es8x/index/v4-message-log.ftl
@@ -1,0 +1,51 @@
+<#-- @ftlvariable name="index" type="java.lang.String" -->
+<#-- @ftlvariable name="@timestamp" type="java.lang.String" -->
+<#-- @ftlvariable name="log" type="io.gravitee.reporter.api.v4.log.MessageLog" -->
+
+{ "index" : { "_index" : "${index}", "_id" : "${log.getCorrelationId()}-${log.getConnectorType().getLabel()}" } }
+<@compress single_line=true>
+{
+  "@timestamp":"${@timestamp}"
+  ,"api-id":"${log.getApiId()}"
+  ,"request-id":"${log.getRequestId()}"
+  ,"client-identifier":"${log.getClientIdentifier()}"
+  ,"correlation-id":"${log.getCorrelationId()}"
+  <#if log.getParentCorrelationId()??>
+  ,"parent-correlation-id":"${log.getParentCorrelationId()}"
+  </#if>
+  ,"operation":"${log.getOperation().getLabel()}"
+  ,"connector-type":"${log.getConnectorType().getLabel()}"
+  ,"connector-id":"${log.getConnectorId()}"
+  ,"message": {
+    "id":"${(log.getMessage().getId())!}"
+    <#if log.getMessage().isError()>
+    ,"error":"${log.getMessage().isError()?c}"
+    </#if>
+    <#if log.getMessage().getPayload()??>
+    ,"payload":"${log.getMessage().getPayload()?j_string}"
+    </#if>
+    <#if log.getMessage().getHeaders()??>
+    ,"headers":{
+      <#list log.getMessage().getHeaders() as headerKey, headerValue>
+        "${headerKey}": [
+        <#list headerValue as value>
+          <#if value??>
+            "${value?j_string}"
+            <#sep>,</#sep>
+          </#if>
+        </#list>
+      ]
+        <#sep>,</#sep>
+      </#list>
+    }
+    </#if>
+    <#if log.getMessage().getMetadata()??>
+    ,"metadata":{
+    <#list log.getMessage().getMetadata() as metadataKey, metadataValue>
+      "${metadataKey}": "${metadataValue}"
+      <#sep>,</#sep>
+    </#list>
+    }
+    </#if>
+  }
+}</@compress>

--- a/src/main/resources/freemarker/es8x/index/v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/index/v4-message-metrics.ftl
@@ -1,0 +1,48 @@
+<#-- @ftlvariable name="@timestamp" type="java.lang.String" -->
+<#-- @ftlvariable name="index" type="java.lang.String" -->
+<#-- @ftlvariable name="pipeline" type="java.lang.String" -->
+<#-- @ftlvariable name="gateway" type="java.lang.String" -->
+<#-- @ftlvariable name="metrics" type="io.gravitee.reporter.api.v4.metric.MessageMetrics" -->
+<#-- @ftlvariable name="contentLength" type="java.lang.Long" -->
+<#-- @ftlvariable name="count" type="java.lang.Long" -->
+<#-- @ftlvariable name="errorCount" type="java.lang.Long" -->
+<#-- @ftlvariable name="gatewayLatencyMs" type="java.lang.Long" -->
+
+{ "index" : { "_index" : "${index}", "_id" : "${metrics.getCorrelationId()}-${metrics.getConnectorType().getLabel()}"} }
+<@compress single_line=true>
+{
+  "gateway":"${gateway}"
+  ,"@timestamp":"${@timestamp}"
+  ,"request-id":"${metrics.getRequestId()}"
+  ,"api-id":"${metrics.getApiId()}"
+  ,"client-identifier":"${metrics.getClientIdentifier()}"
+  ,"correlation-id":"${metrics.getCorrelationId()}"
+  <#if metrics.getParentCorrelationId()??>
+  ,"parent-correlation-id":"${metrics.getParentCorrelationId()}"
+  </#if>
+  ,"operation":"${metrics.getOperation().getLabel()}"
+  ,"connector-type":"${metrics.getConnectorType().getLabel()}"
+  ,"connector-id":"${metrics.getConnectorId()}"
+  <#if contentLength??>
+    ,"content-length":${contentLength}
+  </#if>
+  <#if count??>
+  ,"count":${count}
+  </#if>
+  <#if errorCount??>
+  ,"error-count":"${errorCount}"
+  </#if>
+  <#if metrics.isError()>
+  ,"error":"${metrics.isError()?c}"
+  </#if>
+  <#if gatewayLatencyMs??>
+  ,"gateway-latency-ms":${gatewayLatencyMs}
+  </#if>
+  <#if metrics.getCustomMetrics()??>
+  ,"custom": {
+  <#list metrics.getCustomMetrics() as propKey, propValue>
+    "${propKey}":"${propValue}"<#sep>,
+  </#list>
+  }
+  </#if>
+}</@compress>

--- a/src/main/resources/freemarker/es8x/index/v4-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/index/v4-metrics.ftl
@@ -1,0 +1,110 @@
+<#-- @ftlvariable name="@timestamp" type="java.lang.String" -->
+<#-- @ftlvariable name="index" type="java.lang.String" -->
+<#-- @ftlvariable name="pipeline" type="java.lang.String" -->
+<#-- @ftlvariable name="gateway" type="java.lang.String" -->
+<#-- @ftlvariable name="metrics" type="io.gravitee.reporter.api.v4.metric.Metrics" -->
+<#-- @ftlvariable name="endpointResponseTimeMs" type="java.lang.Long" -->
+<#-- @ftlvariable name="gatewayResponseTimeMs" type="java.lang.Long" -->
+<#-- @ftlvariable name="gatewayLatencyMs" type="java.lang.Long" -->
+<#-- @ftlvariable name="requestContentLength" type="java.lang.Long" -->
+<#-- @ftlvariable name="responseContentLength" type="java.lang.Long" -->
+
+{ "index" : { "_index" : "${index}", "_id" : "${metrics.getRequestId()}"<#if pipeline??>, "pipeline" : "${pipeline}"</#if>} }
+<@compress single_line=true>
+{
+  "gateway":"${gateway}"
+  ,"@timestamp":"${@timestamp}"
+  ,"request-id":"${metrics.getRequestId()}"
+  <#if metrics.getClientIdentifier()??>
+  ,"client-identifier":"${metrics.getClientIdentifier()}"
+  </#if>
+  ,"transaction-id":"${metrics.getTransactionId()}"
+  <#if metrics.getApiId()??>
+  ,"api-id":"${metrics.getApiId()}"
+  </#if>
+  <#if metrics.getPlanId()??>
+  ,"plan-id":"${metrics.getPlanId()}"
+  </#if>
+  <#if metrics.getApplicationId()??>
+  ,"application-id":"${metrics.getApplicationId()}"
+  </#if>
+  <#if metrics.getSubscriptionId()??>
+  ,"subscription-id":"${metrics.getSubscriptionId()}"
+  </#if>
+  <#if metrics.getTenant()??>
+  ,"tenant":"${metrics.getTenant()}"
+  </#if>
+  <#if metrics.getZone()??>
+  ,"zone":"${metrics.getZone()}"
+  </#if>
+  <#if metrics.getHttpMethod()??>
+  ,"http-method":${metrics.getHttpMethod().code()?c}
+  </#if>
+  <#if metrics.getLocalAddress()??>
+  ,"local-address":"${metrics.getLocalAddress()}"
+  </#if>
+  <#if metrics.getRemoteAddress()??>
+  ,"remote-address":"${metrics.getRemoteAddress()}"
+  </#if>
+  <#if metrics.getHost()??>
+  ,"host":"${metrics.getHost()}"
+  </#if>
+  <#if metrics.getUri()??>
+  ,"uri":"${metrics.getUri()}"
+  </#if>
+  <#if metrics.getPathInfo()??>
+  ,"path-info":"${metrics.getPathInfo()}"
+  </#if>
+  <#if metrics.getMappedPath()??>
+  ,"mapped-path":"${metrics.getMappedPath()}"
+  </#if>
+  <#if metrics.getUserAgent()?? && pipeline?has_content>
+  ,"user-agent":"${metrics.getUserAgent()?j_string}"
+  <#else>
+  ,"user-agent":""
+  </#if>
+  <#if requestContentLength??>
+  ,"request-content-length":${requestContentLength}
+  </#if>
+  ,"request-ended":"${metrics.isRequestEnded()?c}"
+  <#if metrics.getEndpoint()??>
+  ,"endpoint":"${metrics.getEndpoint()}"
+  </#if>
+  <#if endpointResponseTimeMs??>
+  ,"endpoint-response-time-ms":${endpointResponseTimeMs}
+  </#if>
+  <#if metrics.getStatus()??>
+  ,"status":${metrics.getStatus()}
+  </#if>
+  <#if responseContentLength??>
+  ,"response-content-length":${responseContentLength}
+  </#if>
+  <#if gatewayResponseTimeMs??>
+  ,"gateway-response-time-ms":${gatewayResponseTimeMs}
+  </#if>
+  <#if gatewayLatencyMs??>
+  ,"gateway-latency-ms":${gatewayLatencyMs}
+  </#if>
+  <#if metrics.getUser()??>
+  ,"user":"${metrics.getUser()}"
+  </#if>
+  <#if metrics.getSecurityType()??>
+  ,"security-type":"${metrics.getSecurityType()}"
+  </#if>
+  <#if metrics.getSecurityToken()??>
+  ,"security-token":"${metrics.getSecurityToken()}"
+  </#if>
+  <#if metrics.getErrorMessage()??>
+  ,"error-message":"${metrics.getErrorMessage()?j_string}"
+  </#if>
+  <#if metrics.getErrorKey()??>
+  ,"error-key":"${metrics.getErrorKey()}"
+  </#if>
+  <#if metrics.getCustomMetrics()??>
+  ,"custom": {
+  <#list metrics.getCustomMetrics() as propKey, propValue>
+    "${propKey}":"${propValue}"<#sep>,
+  </#list>
+  }
+  </#if>
+}</@compress>

--- a/src/main/resources/freemarker/es8x/mapping/index-template-health.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-health.ftl
@@ -1,0 +1,47 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
+        <#if indexLifecyclePolicyHealth??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+            "properties": {
+                "api": {
+                    "type": "keyword"
+                },
+                "available": {
+                    "type": "boolean",
+                    "index": false
+                },
+                "endpoint": {
+                    "type": "keyword"
+                },
+                "gateway": {
+                    "type": "keyword"
+                },
+                "response-time": {
+                    "type": "integer"
+                },
+                "state": {
+                    "type": "integer",
+                    "index": false
+                },
+                "transition": {
+                    "type": "boolean"
+                },
+                "steps": {
+                    "type": "object",
+                    "enabled": false
+                },
+                "success": {
+                    "type": "boolean",
+                    "index": false
+                }
+            }
+    }
+}

--- a/src/main/resources/freemarker/es8x/mapping/index-template-log.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-log.ftl
@@ -1,0 +1,70 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
+        <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "api": {
+                    "type": "keyword"
+                },
+                "client-request": {
+                    "type": "object",
+                    "properties": {
+                        "body":{
+                            "type": "text"
+                        },
+                        "headers":  {
+                           "enabled":  false,
+                           "type": "object"
+                       }
+                    }
+                },
+                "client-response": {
+                    "type": "object",
+                    "properties": {
+                        "body":{
+                            "type": "text"
+                        },
+                        "headers":  {
+                           "enabled":  false,
+                           "type": "object"
+                       }
+                    }
+                },
+                "proxy-request": {
+                    "type": "object",
+                    "properties": {
+                        "body":{
+                            "type": "text"
+                        },
+                        "headers":  {
+                           "enabled":  false,
+                           "type": "object"
+                       }
+                    }
+                },
+                "proxy-response": {
+                    "type": "object",
+                    "properties": {
+                        "body":{
+                            "type": "text"
+                        },
+                        "headers": {
+                            "enabled":  false,
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+    }
+}

--- a/src/main/resources/freemarker/es8x/mapping/index-template-monitor.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-monitor.ftl
@@ -1,0 +1,43 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
+        <#if indexLifecyclePolicyMonitor??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+            "properties": {
+                "os": {
+                    "properties": {
+                        "cpu": {
+                            "properties": {
+                                "load_average": {
+                                    "properties": {
+                                        "1m": {
+                                            "type": "float"
+                                        },
+                                        "5m": {
+                                            "type": "float"
+                                        },
+                                        "15m": {
+                                            "type": "float"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "gateway": {
+                    "type": "keyword"
+                },
+                "hostname": {
+                    "type": "keyword"
+                }
+            }
+    }
+}

--- a/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
@@ -1,0 +1,184 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
+        <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+            "properties": {
+                "@timestamp": {
+                    "type": "date"
+                },
+                "api": {
+                    "type": "keyword"
+                },
+                "api-response-time": {
+                    "type": "long"
+                },
+                "application": {
+                    "type": "keyword"
+                },
+                "endpoint": {
+                    "type": "keyword"
+                },
+                "gateway": {
+                    "type": "keyword"
+                },
+                "local-address": {
+                    "type": "keyword",
+                    "index": false
+                },
+                "message": {
+                    "type": "text"
+                },
+                "method": {
+                    "type": "short"
+                },
+                "plan": {
+                    "type": "keyword"
+                },
+                "proxy-latency": {
+                    "type": "integer"
+                },
+                "remote-address": {
+                    "type": "ip"
+                },
+                "geoip" : {
+                    "properties": {
+                        "continent_name":{
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "country_iso_code":{
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "region_name":{
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "city_name":{
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "location": {
+                            "type": "geo_point"
+                        }
+                    }
+                },
+                "request-content-length": {
+                    "type": "integer",
+                    "index": false
+                },
+                "response-content-length": {
+                    "type": "integer",
+                    "index": false
+                },
+                "response-time": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "short"
+                },
+                "tenant": {
+                    "type": "keyword"
+                },
+                "transaction": {
+                    "type": "keyword"
+                },
+                "uri": {
+                    "type": "keyword"
+                },
+                "path": {
+                    "type": "keyword"
+                },
+                "mapped-path": {
+                    "type": "keyword"
+                },
+                "host": {
+                    "type": "keyword"
+                },
+                "user-agent": {
+                    "type": "keyword"
+                },
+                "user_agent": {
+                    "properties": {
+                        "device": {
+                            "properties": {
+                                "name": {
+                                    "type": "keyword"
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "original": {
+                            "type": "text"
+                        },
+                        "os": {
+                            "properties": {
+                                "full": {
+                                    "type": "text"
+                                },
+                                "name": {
+                                    "type": "keyword",
+                                    "index": true
+                                },
+                                "version": {
+                                    "type": "keyword",
+                                    "index": true
+                                }
+                            }
+                        },
+                        "os_name": {
+                            "type": "keyword",
+                            "index": true
+                        },
+                        "version": {
+                            "type": "text"
+                        }
+                    }
+                },
+                "user": {
+                    "type": "keyword"
+                },
+                "security-type": {
+                    "type": "keyword",
+                    "index": true
+                },
+                "security-token": {
+                    "type": "keyword",
+                    "index": true
+                },
+                "error-key": {
+                    "type": "keyword",
+                    "index": true
+                },
+                "subscription": {
+                    "type": "keyword"
+                },
+                "zone": {
+                    "type": "keyword"
+                }
+                <#if extendedRequestMappingTemplate??>,<#include "/${extendedRequestMappingTemplate}"></#if>
+            },
+            "dynamic_templates": [
+                {
+                    "strings_as_keywords": {
+                        "path_match": "custom.*",
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "type": "keyword"
+                        }
+                    }
+                }
+            ]
+    }
+}

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-log.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-log.ftl
@@ -1,0 +1,79 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
+        <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+        "properties": {
+            "@timestamp": {
+                "type": "date"
+            },
+            "api-id": {
+                "type": "keyword"
+            },
+            "request-id": {
+                "type": "keyword"
+            },
+            "client-identifier": {
+                "type": "keyword"
+            },
+            "request-ended": {
+                "type": "boolean"
+            },
+            "entrypoint-request": {
+                "type": "object",
+                "properties": {
+                    "body":{
+                        "type": "text"
+                    },
+                    "headers":  {
+                       "enabled":  false,
+                       "type": "object"
+                   }
+                }
+            },
+            "entrypoint-response": {
+                "type": "object",
+                "properties": {
+                    "body":{
+                        "type": "text"
+                    },
+                    "headers":  {
+                       "enabled":  false,
+                       "type": "object"
+                   }
+                }
+            },
+            "endpoint-request": {
+                "type": "object",
+                "properties": {
+                    "body":{
+                        "type": "text"
+                    },
+                    "headers":  {
+                       "enabled":  false,
+                       "type": "object"
+                   }
+                }
+            },
+            "endpoint-response": {
+                "type": "object",
+                "properties": {
+                    "body":{
+                        "type": "text"
+                    },
+                    "headers": {
+                        "enabled":  false,
+                        "type": "object"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-log.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-log.ftl
@@ -1,0 +1,65 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
+        <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+        "properties": {
+            "@timestamp": {
+                "type": "date"
+            },
+            "api-id": {
+                "type": "keyword"
+            },
+            "request-id": {
+                "type": "keyword"
+            },
+            "client-identifier": {
+                "type": "keyword"
+            },
+            "correlation-id": {
+                "type": "keyword"
+            },
+            "parent-correlation-id": {
+                "type": "keyword"
+            },
+            "operation": {
+                "type": "keyword"
+            },
+            "connector-type": {
+                "type": "keyword"
+            },
+            "connector-id": {
+                "type": "keyword"
+            },
+            "message": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "keyword"
+                    },
+                    "payload":{
+                        "type": "text"
+                    },
+                    "headers":{
+                        "enabled": false,
+                        "type": "object"
+                    },
+                    "metadata":  {
+                       "enabled": false,
+                       "type": "object"
+                    },
+                    "error":  {
+                        "type": "boolean"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-metrics.ftl
@@ -1,0 +1,73 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
+        <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+        "properties": {
+            "gateway": {
+                "type": "keyword"
+            },
+            "@timestamp": {
+                "type": "date"
+            },
+            "api-id": {
+                "type": "keyword"
+            },
+            "request-id": {
+                "type": "keyword"
+            },
+            "client-identifier": {
+                "type": "keyword"
+            },
+            "correlation-id": {
+                "type": "keyword"
+            },
+            "parent-correlation-id": {
+                "type": "keyword"
+            },
+            "operation": {
+                "type": "keyword"
+            },
+            "connector-type": {
+                "type": "keyword"
+            },
+            "connector-id": {
+                "type": "keyword"
+            },
+            "content-length": {
+                "type": "integer"
+            },
+            "count": {
+                "type": "integer"
+            },
+            "error-count": {
+                "type": "integer"
+            },
+            "error": {
+                "type": "boolean"
+            },
+            "gateway-latency-ms": {
+                "type": "integer"
+            }
+            <#if extendedRequestMappingTemplate??>,<#include "/${extendedRequestMappingTemplate}"></#if>
+        },
+        "dynamic_templates": [
+            {
+                "strings_as_keywords": {
+                    "path_match": "custom.*",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "type": "keyword"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
@@ -1,0 +1,193 @@
+<#ftl output_format="JSON">
+{
+    "index_patterns": ["${indexName}*"],
+    "settings": {
+        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
+        <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+        "index.number_of_shards":${numberOfShards},
+        "index.number_of_replicas":${numberOfReplicas},
+        "index.refresh_interval": "${refreshInterval}"
+        <#if extendedSettingsTemplate??>,<#include "/${extendedSettingsTemplate}"></#if>
+    },
+    "mappings": {
+        "properties": {
+            "gateway": {
+                "type": "keyword"
+            },
+            "@timestamp": {
+                "type": "date"
+            },
+            "transaction-id": {
+                "type": "keyword"
+            },
+            "api-id": {
+                "type": "keyword"
+            },
+            "request-id": {
+                "type": "keyword"
+            },
+            "plan-id": {
+                "type": "keyword"
+            },
+            "application-id": {
+                "type": "keyword"
+            },
+            "subscription-id": {
+                "type": "keyword"
+            },
+            "client-identifier": {
+                "type": "keyword"
+            },
+            "tenant": {
+                "type": "keyword"
+            },
+            "zone": {
+                "type": "keyword"
+            },
+            "http-method": {
+                "type": "short"
+            },
+            "local-address": {
+                "type": "keyword",
+                "index": false
+            },
+            "remote-address": {
+                "type": "ip"
+            },
+            "host": {
+                "type": "keyword"
+            },
+            "uri": {
+                "type": "keyword"
+            },
+            "path": {
+                "type": "keyword"
+            },
+            "mapped-path": {
+                "type": "keyword"
+            },
+            "user-agent": {
+                "type": "keyword"
+            },
+            "user_agent": {
+                "properties": {
+                    "device": {
+                        "properties": {
+                            "name": {
+                                "type": "keyword"
+                            }
+                        }
+                    },
+                    "name": {
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "original": {
+                        "type": "text"
+                    },
+                    "os": {
+                        "properties": {
+                            "full": {
+                                "type": "text"
+                            },
+                            "name": {
+                                "type": "keyword",
+                                "index": true
+                            },
+                            "version": {
+                                "type": "keyword",
+                                "index": true
+                            }
+                        }
+                    },
+                    "os_name": {
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "version": {
+                        "type": "text"
+                    }
+                }
+            },
+            "request-content-length": {
+                "type": "integer",
+                "index": false
+            },
+            "request-ended": {
+                "type": "boolean"
+            },
+            "endpoint": {
+                "type": "keyword"
+            },
+            "endpoint-response-time-ms": {
+                "type": "long"
+            },
+            "status": {
+                "type": "short"
+            },
+            "response-content-length": {
+                "type": "integer",
+                "index": false
+            },
+            "gateway-latency-ms": {
+                "type": "integer"
+            },
+            "gateway-response-time-ms": {
+                "type": "integer"
+            },
+            "geoip" : {
+                "properties": {
+                    "continent_name":{
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "country_iso_code":{
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "region_name":{
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "city_name":{
+                        "type": "keyword",
+                        "index": true
+                    },
+                    "location": {
+                        "type": "geo_point"
+                    }
+                }
+            },
+            "user": {
+                "type": "keyword"
+            },
+            "security-type": {
+                "type": "keyword",
+                "index": true
+            },
+            "security-token": {
+                "type": "keyword",
+                "index": true
+            },
+            "error-message": {
+                "type": "text"
+            },
+            "error-key": {
+                "type": "keyword",
+                "index": true
+            }
+            <#if extendedRequestMappingTemplate??>,<#include "/${extendedRequestMappingTemplate}"></#if>
+        },
+        "dynamic_templates": [
+            {
+                "strings_as_keywords": {
+                    "path_match": "custom.*",
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "type": "keyword"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
@@ -44,7 +44,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 @ContextConfiguration(classes = { HttpClientTest.TestConfig.class })
 public class HttpClientTest {
 
-    public static final String ELASTICSEARCH_DEFAULT_VERSION = "7.17.8";
+    public static final String ELASTICSEARCH_DEFAULT_VERSION = "8.5.2";
 
     public static final String CLUSTER_NAME = "gravitee_test";
 
@@ -142,6 +142,9 @@ public class HttpClientTest {
                 "docker.elastic.co/elasticsearch/elasticsearch:" + elasticsearchVersion
             );
             elasticsearchContainer.withEnv("cluster.name", CLUSTER_NAME);
+            if (elasticsearchVersion.startsWith("8")) {
+                elasticsearchContainer.withEnv("xpack.security.enabled", "false");
+            }
             elasticsearchContainer.start();
             return elasticsearchContainer;
         }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-427

**Description**

Add ES 8 support
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-es8-support-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/4.1.0-es8-support-SNAPSHOT/gravitee-common-elasticsearch-4.1.0-es8-support-SNAPSHOT.zip)
  <!-- Version placeholder end -->
