### PR TITLE
fix: rename metrics for message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
 
     <groupId>io.gravitee.elasticsearch</groupId>
     <artifactId>gravitee-common-elasticsearch</artifactId>
-    <version>4.1.0-alpha.2</version>
+    <version>4.1.0-alpha.3</version>
 
     <name>Gravitee.io APIM - Elasticsearch - Common</name>
 
     <properties>
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
         <gravitee-common.version>2.1.0-alpha.3</gravitee-common.version>
-        <gravitee-reporter-api.version>1.25.0-alpha.1</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.25.0-alpha.2</gravitee-reporter-api.version>
         <freemarker.version>2.3.31</freemarker.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <testcontainers.version>1.17.6</testcontainers.version>

--- a/src/main/resources/freemarker/es7x/index/message-metrics-v4.ftl
+++ b/src/main/resources/freemarker/es7x/index/message-metrics-v4.ftl
@@ -5,7 +5,7 @@
 <#-- @ftlvariable name="metrics" type="io.gravitee.reporter.api.v4.metric.MessageMetrics" -->
 <#-- @ftlvariable name="contentLength" type="java.lang.Long" -->
 <#-- @ftlvariable name="count" type="java.lang.Long" -->
-<#-- @ftlvariable name="errorsCount" type="java.lang.Long" -->
+<#-- @ftlvariable name="errorCount" type="java.lang.Long" -->
 <#-- @ftlvariable name="gatewayLatencyMs" type="java.lang.Long" -->
 
 { "index" : { "_index" : "${index}", "_id" : "${metrics.getCorrelationId()}-${metrics.getConnectorType().getLabel()}"} }
@@ -29,8 +29,8 @@
   <#if count??>
   ,"count":${count}
   </#if>
-  <#if errorsCount??>
-  ,"errors-count":"${errorsCount}"
+  <#if errorCount??>
+  ,"error-count":"${errorCount}"
   </#if>
   <#if gatewayLatencyMs??>
   ,"gateway-latency-ms":${gatewayLatencyMs}


### PR DESCRIPTION
rename errorsCount to errorCount in message metrics
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-fix-metrics-name-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/4.1.0-fix-metrics-name-SNAPSHOT/gravitee-common-elasticsearch-4.1.0-fix-metrics-name-SNAPSHOT.zip)
  <!-- Version placeholder end -->
