### PR TITLE
Apim 490 add error metric

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
         <gravitee-common.version>2.1.0-alpha.3</gravitee-common.version>
-        <gravitee-reporter-api.version>1.25.0-apim-490-add-error-metric-SNAPSHOT</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.25.0-alpha.4</gravitee-reporter-api.version>
         <freemarker.version>2.3.31</freemarker.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <testcontainers.version>1.17.6</testcontainers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
 
     <groupId>io.gravitee.elasticsearch</groupId>
     <artifactId>gravitee-common-elasticsearch</artifactId>
-    <version>4.1.0-alpha.6</version>
+    <version>4.1.0-apim-490-add-error-metric-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Elasticsearch - Common</name>
 
     <properties>
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
         <gravitee-common.version>2.1.0-alpha.3</gravitee-common.version>
-        <gravitee-reporter-api.version>1.25.0-alpha.3</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.25.0-apim-490-add-error-metric-SNAPSHOT</gravitee-reporter-api.version>
         <freemarker.version>2.3.31</freemarker.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <testcontainers.version>1.17.6</testcontainers.version>

--- a/src/main/resources/freemarker/es7x/index/v4-message-log.ftl
+++ b/src/main/resources/freemarker/es7x/index/v4-message-log.ftl
@@ -19,7 +19,7 @@
   ,"message": {
     "id":"${(log.getMessage().getId())!}"
     <#if log.getMessage().isError()>
-    ,"error":"${log.getMessage().isError()}"
+    ,"error":"${log.getMessage().isError()?c}"
     </#if>
     <#if log.getMessage().getPayload()??>
     ,"payload":"${log.getMessage().getPayload()?j_string}"

--- a/src/main/resources/freemarker/es7x/index/v4-message-log.ftl
+++ b/src/main/resources/freemarker/es7x/index/v4-message-log.ftl
@@ -18,6 +18,9 @@
   ,"connector-id":"${log.getConnectorId()}"
   ,"message": {
     "id":"${(log.getMessage().getId())!}"
+    <#if log.getMessage().isError()>
+    ,"error":"${log.getMessage().isError()}"
+    </#if>
     <#if log.getMessage().getPayload()??>
     ,"payload":"${log.getMessage().getPayload()?j_string}"
     </#if>

--- a/src/main/resources/freemarker/es7x/index/v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/index/v4-message-metrics.ftl
@@ -33,7 +33,7 @@
   ,"error-count":"${errorCount}"
   </#if>
   <#if metrics.isError()>
-  ,"error":"${metrics.isError()}"
+  ,"error":"${metrics.isError()?c}"
   </#if>
   <#if gatewayLatencyMs??>
   ,"gateway-latency-ms":${gatewayLatencyMs}

--- a/src/main/resources/freemarker/es7x/index/v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/index/v4-message-metrics.ftl
@@ -32,6 +32,9 @@
   <#if errorCount??>
   ,"error-count":"${errorCount}"
   </#if>
+  <#if metrics.isError()>
+  ,"error":"${metrics.isError()}"
+  </#if>
   <#if gatewayLatencyMs??>
   ,"gateway-latency-ms":${gatewayLatencyMs}
   </#if>

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-log.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-log.ftl
@@ -48,13 +48,16 @@
                         "type": "text"
                     },
                     "headers":{
-                        "enabled":  false,
+                        "enabled": false,
                         "type": "object"
                     },
                     "metadata":  {
-                       "enabled":  false,
+                       "enabled": false,
                        "type": "object"
-                   }
+                    },
+                    "error":  {
+                        "type": "boolean"
+                    }
                 }
             }
         }

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
@@ -47,7 +47,7 @@
             "count": {
                 "type": "integer"
             },
-            "errors-count": {
+            "error-count": {
                 "type": "integer"
             },
             "error": {

--- a/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
@@ -50,6 +50,9 @@
             "errors-count": {
                 "type": "integer"
             },
+            "error": {
+                "type": "boolean"
+            },
             "gateway-latency-ms": {
                 "type": "integer"
             }


### PR DESCRIPTION
Description

Adding error status on message metrics.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-apim-490-add-error-metric-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/4.1.0-apim-490-add-error-metric-SNAPSHOT/gravitee-common-elasticsearch-4.1.0-apim-490-add-error-metric-SNAPSHOT.zip)
  <!-- Version placeholder end -->
