### PR TITLE
fix(deps): upgrade gravitee-bom & alpha version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
     <name>Gravitee.io APIM - Elasticsearch - Common</name>
 
     <properties>
-        <gravitee-bom.version>3.0.0</gravitee-bom.version>
-        <gravitee-common.version>2.1.0-alpha.3</gravitee-common.version>
-        <gravitee-reporter-api.version>1.25.0-alpha.4</gravitee-reporter-api.version>
+        <gravitee-bom.version>4.0.0</gravitee-bom.version>
+        <gravitee-common.version>2.1.0</gravitee-common.version>
+        <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>
         <freemarker.version>2.3.31</freemarker.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <testcontainers.version>1.17.6</testcontainers.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.1.0-upgrade-deps-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/4.1.0-upgrade-deps-SNAPSHOT/gravitee-common-elasticsearch-4.1.0-upgrade-deps-SNAPSHOT.zip)
  <!-- Version placeholder end -->
