### PR TITLE
feat: use wildcards when computing elastic query indices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/io/gravitee/elasticsearch/utils/DateUtilsTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/utils/DateUtilsTest.java
@@ -18,7 +18,12 @@ package io.gravitee.elasticsearch.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import org.junit.jupiter.api.Test;
+import java.util.TimeZone;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -26,15 +31,71 @@ import org.junit.jupiter.api.Test;
  */
 public class DateUtilsTest {
 
-    @Test
-    void shouldReturnSingleDate() {
-        List<String> indices = DateUtils.rangedIndices(1474581851724L, 1474582151724L);
-        assertThat(indices).hasSize(1);
+    @BeforeAll
+    public static void setup() {
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT+01:00"));
     }
 
-    @Test
-    void shouldReturnMultipleDate() {
-        List<String> indices = DateUtils.rangedIndices(1473459236000L, 1474582436000L);
-        assertThat(indices).hasSize(14);
+    @ParameterizedTest
+    @MethodSource("provideDates")
+    void shouldComputeIndices(long from, long to, List<String> expected) {
+        List<String> indices = DateUtils.rangedIndices(from, to);
+        assertThat(indices).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> provideDates() {
+        return Stream.of(
+            // from 5 JAN to 10 JAN
+            Arguments.of(
+                1672873200000L,
+                1673305259000L,
+                List.of("2023.01.05", "2023.01.06", "2023.01.07", "2023.01.08", "2023.01.09", "2023.01.10")
+            ),
+            // from 1 JAN to 31 JAN
+            Arguments.of(1672527600000L, 1675119659000L, List.of("2023.01.*")),
+            // from 1 JAN to 4 MARCH
+            Arguments.of(
+                1672527600000L,
+                1677884459000L,
+                List.of("2023.01.*", "2023.02.*", "2023.03.01", "2023.03.02", "2023.03.03", "2023.03.04")
+            ),
+            // from 1 JAN to 31 MARCH
+            Arguments.of(1672527600000L, 1680278352000L, List.of("2023.01.*", "2023.02.*", "2023.03.*")),
+            // form 28 JAN to 4 MARCH
+            Arguments.of(
+                1674860400000L,
+                1677884459000L,
+                List.of(
+                    "2023.01.28",
+                    "2023.01.29",
+                    "2023.01.30",
+                    "2023.01.31",
+                    "2023.02.*",
+                    "2023.03.01",
+                    "2023.03.02",
+                    "2023.03.03",
+                    "2023.03.04"
+                )
+            ),
+            // from 25 DEC 2022 to 2 FEB 2023
+            Arguments.of(
+                1671966915000L,
+                1675336515000L,
+                List.of(
+                    "2022.12.25",
+                    "2022.12.26",
+                    "2022.12.27",
+                    "2022.12.28",
+                    "2022.12.29",
+                    "2022.12.30",
+                    "2022.12.31",
+                    "2023.01.*",
+                    "2023.02.01",
+                    "2023.02.02"
+                )
+            ),
+            // from 1 DEC 2022 to 31 MARCH 2023
+            Arguments.of(1669893315000L, 1680261315000L, List.of("2022.12.*", "2023.01.*", "2023.02.*", "2023.03.*"))
+        );
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-844

**Description**

Use wildcards when computing elastic query indices. The reason behind that is to be able to compute analytics for date range greater than 90 days. Today we concat the daily indices, that why we can reich the request size limit
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.2.0-apim-844-use-wildcards-on-indices-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/4.2.0-apim-844-use-wildcards-on-indices-SNAPSHOT/gravitee-common-elasticsearch-4.2.0-apim-844-use-wildcards-on-indices-SNAPSHOT.zip)
  <!-- Version placeholder end -->
