### PR TITLE
fix: restore ingest plugins templates

### DIFF
--- a/src/main/resources/geoip.ftl
+++ b/src/main/resources/geoip.ftl
@@ -1,0 +1,35 @@
+<@compress single_line=true>
+{
+  "geoip" : {
+    "field" : "remote-address"
+  }
+},
+{
+  "set": {
+      "field": "geoip.city_name",
+      "value": "Unknown",
+      "override": false
+   }
+},
+{
+  "set": {
+      "field": "geoip.continent_name",
+      "value": "Unknown",
+      "override": false
+   }
+},
+{
+    "set": {
+        "field": "geoip.country_iso_code",
+        "value": "Unknown",
+        "override": false
+    }
+},
+{
+  "set": {
+    "field": "geoip.region_name",
+    "value": "Unknown",
+    "override": false
+  }
+}
+</@compress>

--- a/src/main/resources/gravitee.ftl
+++ b/src/main/resources/gravitee.ftl
@@ -1,0 +1,8 @@
+<@compress single_line=true>
+    {
+        "gravitee-elasticsearch-ingest-plugin" : {
+            "apiField" : "api",
+            "applicationField" : "application"
+        }
+    }
+</@compress>

--- a/src/main/resources/pipeline.ftl
+++ b/src/main/resources/pipeline.ftl
@@ -1,0 +1,8 @@
+<@compress single_line=true>
+{
+  "description" : "Gravitee pipeline",
+  "processors" : [
+    ${processors}
+  ]
+}
+</@compress>

--- a/src/main/resources/user_agent.ftl
+++ b/src/main/resources/user_agent.ftl
@@ -1,0 +1,29 @@
+<@compress single_line=true>
+{
+  "user_agent" : {
+    <#if userAgentRegexFile??>"regex_file": "${userAgentRegexFile}",</#if>
+    "field": "user-agent"
+  }
+},
+{
+  "set": {
+      "field": "user_agent.name",
+      "value": "Unknown",
+      "override": false
+   }
+},
+{
+  "set": {
+      "field": "user_agent.os_name",
+      "value": "{{user_agent.os.name}}",
+      "override": false
+   }
+},
+{
+  "set": {
+      "field": "user_agent.os_name",
+      "value": "Unknown",
+      "override": false
+   }
+}
+</@compress>


### PR DESCRIPTION
This templates are required by the PipelineConfiguration class in the reporter.

We missed them because the version was not bumped in the reporter.

They should move to the reporter itself, but implies quite some changes in apim and requires a bit of thinking around all this.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.1-fix-restore-ingest-plugins-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/5.0.1-fix-restore-ingest-plugins-SNAPSHOT/gravitee-common-elasticsearch-5.0.1-fix-restore-ingest-plugins-SNAPSHOT.zip)
  <!-- Version placeholder end -->
