### PR TITLE
fix: deprecate freemarker component

### DIFF
--- a/src/main/java/io/gravitee/elasticsearch/templating/freemarker/FreeMarkerComponent.java
+++ b/src/main/java/io/gravitee/elasticsearch/templating/freemarker/FreeMarkerComponent.java
@@ -40,9 +40,13 @@ import org.springframework.beans.factory.annotation.Value;
 /**
  * Utility Spring bean that encapsulates FreeMarker tools.
  *
+ * @deprecated This class is marked for removal as dependant modules should use the
+ * FreemarkerComponent class made available in gravitee-common since version 3.3.0.
+ *
  * @author Guillaume Waignier
  * @author Sebastien Devaux
  */
+@Deprecated(since = "5.0.1", forRemoval = true)
 public class FreeMarkerComponent implements InitializingBean {
 
     /** Logger. */


### PR DESCRIPTION
FreemarkerCompoennt is marked for removal as dependant modules should use the one made available in gravitee-common since version 3.3.0.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.0.1-fix-deprecate-freemarker-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/5.0.1-fix-deprecate-freemarker-SNAPSHOT/gravitee-common-elasticsearch-5.0.1-fix-deprecate-freemarker-SNAPSHOT.zip)
  <!-- Version placeholder end -->
