### PR TITLE
fix: add j_string to escape endpoint URL

### DIFF
--- a/src/main/resources/freemarker/es7x/index/health.ftl
+++ b/src/main/resources/freemarker/es7x/index/health.ftl
@@ -9,7 +9,7 @@
 {
     "gateway":"${gateway}",
     "api":"${status.getApi()}",
-    "endpoint":"${status.getEndpoint()}",
+    "endpoint":"${status.getEndpoint()?j_string}",
     "available":${status.isAvailable()?c},
     "response-time":${status.getResponseTime()},
     "success":${status.isSuccess()?c},
@@ -20,7 +20,7 @@
         {"name": "${step.getName()}",
         "success":${step.isSuccess()?c},
         "request": {
-            "uri":"${step.getRequest().getUri()}",
+            "uri":"${step.getRequest().getUri()?j_string}",
             "method":"${step.getRequest().getMethod()}"
             <#if step.getRequest().getBody()??>
             ,"body":"${step.getRequest().getBody()?j_string}"

--- a/src/main/resources/freemarker/es7x/index/log.ftl
+++ b/src/main/resources/freemarker/es7x/index/log.ftl
@@ -6,7 +6,7 @@
   <#if log.getClientRequest()??>
   ,"client-request": {
   "method":"${log.getClientRequest().getMethod()}",
-  "uri":"${log.getClientRequest().getUri()}"
+  "uri":"${log.getClientRequest().getUri()?j_string}"
     <#if log.getClientRequest().getBody()??>
     ,"body":"${log.getClientRequest().getBody()?j_string}"
     </#if>
@@ -51,7 +51,7 @@
   <#if log.getProxyRequest()??>
   ,"proxy-request": {
   "method":"${log.getProxyRequest().getMethod()}",
-  "uri":"${log.getProxyRequest().getUri()}"
+  "uri":"${log.getProxyRequest().getUri()?j_string}"
     <#if log.getProxyRequest().getBody()??>
     ,"body":"${log.getProxyRequest().getBody()?j_string}"
     </#if>

--- a/src/main/resources/freemarker/es7x/index/request.ftl
+++ b/src/main/resources/freemarker/es7x/index/request.ftl
@@ -5,7 +5,7 @@
   ,"@timestamp":"${@timestamp}"
   ,"transaction":"${metrics.getTransactionId()}"
   ,"method":${metrics.getHttpMethod().code()?c}
-  ,"uri":"${metrics.getUri()}"
+  ,"uri":"${metrics.getUri()?j_string}"
   ,"status":${metrics.getStatus()}
   ,"response-time":${metrics.getProxyResponseTimeMs()}
   <#if apiResponseTime??>
@@ -32,7 +32,7 @@
   ,"local-address":"${metrics.getLocalAddress()}"
   ,"remote-address":"${metrics.getRemoteAddress()}"
   <#if metrics.getEndpoint()??>
-  ,"endpoint":"${metrics.getEndpoint()}"
+  ,"endpoint":"${metrics.getEndpoint()?j_string}"
   </#if>
   <#if metrics.getTenant()??>
   ,"tenant":"${metrics.getTenant()}"

--- a/src/main/resources/freemarker/es7x/index/v4-log.ftl
+++ b/src/main/resources/freemarker/es7x/index/v4-log.ftl
@@ -13,7 +13,7 @@
   <#if log.getEntrypointRequest()??>
   ,"entrypoint-request": {
   "method":"${log.getEntrypointRequest().getMethod()}",
-  "uri":"${log.getEntrypointRequest().getUri()}"
+  "uri":"${log.getEntrypointRequest().getUri()?j_string}"
     <#if log.getEntrypointRequest().getBody()??>
     ,"body":"${log.getEntrypointRequest().getBody()?j_string}"
     </#if>
@@ -60,7 +60,7 @@
   <#if log.getEndpointRequest()??>
   ,"endpoint-request": {
   "method":"${log.getEndpointRequest().getMethod()}",
-  "uri":"${log.getEndpointRequest().getUri()}"
+  "uri":"${log.getEndpointRequest().getUri()?j_string}"
     <#if log.getEndpointRequest().getBody()??>
     ,"body":"${log.getEndpointRequest().getBody()?j_string}"
     </#if>

--- a/src/main/resources/freemarker/es7x/index/v4-metrics.ftl
+++ b/src/main/resources/freemarker/es7x/index/v4-metrics.ftl
@@ -50,7 +50,7 @@
   ,"host":"${metrics.getHost()}"
   </#if>
   <#if metrics.getUri()??>
-  ,"uri":"${metrics.getUri()}"
+  ,"uri":"${metrics.getUri()?j_string}"
   </#if>
   <#if metrics.getPathInfo()??>
   ,"path-info":"${metrics.getPathInfo()}"
@@ -68,7 +68,7 @@
   </#if>
   ,"request-ended":"${metrics.isRequestEnded()?c}"
   <#if metrics.getEndpoint()??>
-  ,"endpoint":"${metrics.getEndpoint()}"
+  ,"endpoint":"${metrics.getEndpoint()?j_string}"
   </#if>
   <#if endpointResponseTimeMs??>
   ,"endpoint-response-time-ms":${endpointResponseTimeMs}

--- a/src/main/resources/freemarker/es8x/index/health.ftl
+++ b/src/main/resources/freemarker/es8x/index/health.ftl
@@ -9,7 +9,7 @@
 {
     "gateway":"${gateway}",
     "api":"${status.getApi()}",
-    "endpoint":"${status.getEndpoint()}",
+    "endpoint":"${status.getEndpoint()?j_string}",
     "available":${status.isAvailable()?c},
     "response-time":${status.getResponseTime()},
     "success":${status.isSuccess()?c},
@@ -20,7 +20,7 @@
         {"name": "${step.getName()}",
         "success":${step.isSuccess()?c},
         "request": {
-            "uri":"${step.getRequest().getUri()}",
+            "uri":"${step.getRequest().getUri()?j_string}",
             "method":"${step.getRequest().getMethod()}"
             <#if step.getRequest().getBody()??>
             ,"body":"${step.getRequest().getBody()?j_string}"

--- a/src/main/resources/freemarker/es8x/index/log.ftl
+++ b/src/main/resources/freemarker/es8x/index/log.ftl
@@ -6,7 +6,7 @@
   <#if log.getClientRequest()??>
   ,"client-request": {
   "method":"${log.getClientRequest().getMethod()}",
-  "uri":"${log.getClientRequest().getUri()}"
+  "uri":"${log.getClientRequest().getUri()?j_string}"
     <#if log.getClientRequest().getBody()??>
     ,"body":"${log.getClientRequest().getBody()?j_string}"
     </#if>
@@ -51,7 +51,7 @@
   <#if log.getProxyRequest()??>
   ,"proxy-request": {
   "method":"${log.getProxyRequest().getMethod()}",
-  "uri":"${log.getProxyRequest().getUri()}"
+  "uri":"${log.getProxyRequest().getUri()?j_string}"
     <#if log.getProxyRequest().getBody()??>
     ,"body":"${log.getProxyRequest().getBody()?j_string}"
     </#if>

--- a/src/main/resources/freemarker/es8x/index/request.ftl
+++ b/src/main/resources/freemarker/es8x/index/request.ftl
@@ -5,7 +5,7 @@
   ,"@timestamp":"${@timestamp}"
   ,"transaction":"${metrics.getTransactionId()}"
   ,"method":${metrics.getHttpMethod().code()?c}
-  ,"uri":"${metrics.getUri()}"
+  ,"uri":"${metrics.getUri()?j_string}"
   ,"status":${metrics.getStatus()}
   ,"response-time":${metrics.getProxyResponseTimeMs()}
   <#if apiResponseTime??>
@@ -32,7 +32,7 @@
   ,"local-address":"${metrics.getLocalAddress()}"
   ,"remote-address":"${metrics.getRemoteAddress()}"
   <#if metrics.getEndpoint()??>
-  ,"endpoint":"${metrics.getEndpoint()}"
+  ,"endpoint":"${metrics.getEndpoint()?j_string}"
   </#if>
   <#if metrics.getTenant()??>
   ,"tenant":"${metrics.getTenant()}"

--- a/src/main/resources/freemarker/es8x/index/v4-log.ftl
+++ b/src/main/resources/freemarker/es8x/index/v4-log.ftl
@@ -13,7 +13,7 @@
   <#if log.getEntrypointRequest()??>
   ,"entrypoint-request": {
   "method":"${log.getEntrypointRequest().getMethod()}",
-  "uri":"${log.getEntrypointRequest().getUri()}"
+  "uri":"${log.getEntrypointRequest().getUri()?j_string}"
     <#if log.getEntrypointRequest().getBody()??>
     ,"body":"${log.getEntrypointRequest().getBody()?j_string}"
     </#if>
@@ -60,7 +60,7 @@
   <#if log.getEndpointRequest()??>
   ,"endpoint-request": {
   "method":"${log.getEndpointRequest().getMethod()}",
-  "uri":"${log.getEndpointRequest().getUri()}"
+  "uri":"${log.getEndpointRequest().getUri()?j_string}"
     <#if log.getEndpointRequest().getBody()??>
     ,"body":"${log.getEndpointRequest().getBody()?j_string}"
     </#if>

--- a/src/main/resources/freemarker/es8x/index/v4-metrics.ftl
+++ b/src/main/resources/freemarker/es8x/index/v4-metrics.ftl
@@ -50,7 +50,7 @@
   ,"host":"${metrics.getHost()}"
   </#if>
   <#if metrics.getUri()??>
-  ,"uri":"${metrics.getUri()}"
+  ,"uri":"${metrics.getUri()?j_string}"
   </#if>
   <#if metrics.getPathInfo()??>
   ,"path-info":"${metrics.getPathInfo()}"
@@ -68,7 +68,7 @@
   </#if>
   ,"request-ended":"${metrics.isRequestEnded()?c}"
   <#if metrics.getEndpoint()??>
-  ,"endpoint":"${metrics.getEndpoint()}"
+  ,"endpoint":"${metrics.getEndpoint()?j_string}"
   </#if>
   <#if endpointResponseTimeMs??>
   ,"endpoint-response-time-ms":${endpointResponseTimeMs}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3180

**Description**

this fix this error
for es8:
`{"type":"json_parse_exception","reason":"Unrecognized character escape '%' (code 37)...`

for es7:
`ERROR i.g.e.client.http.HttpClient - An error occurs while indexing data into ES: indice[gravitee-log-2023.11.02] error[failed to parse]` if you can you API with escaped % like : `http://localhost:8082/echo?abc=\%`

Same change as [here](https://github.com/gravitee-io/gravitee-reporter-common/pull/9) but for APIM 3.20.x

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.2.1-APIM-3180-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/4.2.1-APIM-3180-SNAPSHOT/gravitee-common-elasticsearch-4.2.1-APIM-3180-SNAPSHOT.zip)
  <!-- Version placeholder end -->
