### PR TITLE
feat: add method to put index template

### DIFF
--- a/src/main/java/io/gravitee/elasticsearch/client/Client.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/Client.java
@@ -42,6 +42,7 @@ public interface Client {
 
     Single<BulkResponse> bulk(List<Buffer> data, boolean forceRefresh);
     Completable putTemplate(String templateName, String template);
+    Completable putIndexTemplate(String templateName, String template);
     Completable putPipeline(String templateName, String template);
     Single<SearchResponse> search(String indexes, String type, String query);
     Single<CountResponse> count(String indexes, String type, String query);

--- a/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
@@ -98,6 +98,41 @@ public class HttpClientTest {
     }
 
     @Test
+    public void shouldPutIndexTemplate() throws InterruptedException {
+        String template =
+            """
+                {
+                  "index_patterns": ["te*", "bar*"],
+                  "template": {
+                    "settings": {
+                      "number_of_shards": 1
+                    },
+                    "mappings": {
+                      "_source": {
+                        "enabled": true
+                      },
+                      "properties": {
+                        "host_name": {
+                          "type": "keyword"
+                        },
+                        "created_at": {
+                          "type": "date",
+                          "format": "EEE MMM dd HH:mm:ss Z yyyy"
+                        }
+                      }
+                    },
+                    "aliases": {
+                      "mydata": { }
+                    }
+                  },
+                  "priority": 500
+                }
+                """;
+
+        client.putIndexTemplate("gravitee_test_index_template", template).test().await().assertNoErrors().assertComplete();
+    }
+
+    @Test
     public void shouldNotGetAlias() throws InterruptedException {
         Maybe<JsonNode> alias = client.getAlias("gravitee_test_alias");
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3014

**Description**

Add method to put index template

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.0-apim3014-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/5.1.0-apim3014-SNAPSHOT/gravitee-common-elasticsearch-5.1.0-apim3014-SNAPSHOT.zip)
  <!-- Version placeholder end -->
