### PR TITLE
feat: get index field types

### DIFF
--- a/src/main/java/io/gravitee/elasticsearch/client/Client.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/Client.java
@@ -35,6 +35,7 @@ import java.util.List;
 public interface Client {
     Single<ElasticsearchInfo> getInfo() throws ElasticsearchException;
     Single<Health> getClusterHealth();
+    Single<List<String>> getFieldTypes(String indexName, String fieldName);
 
     default Single<BulkResponse> bulk(List<Buffer> data) {
         return bulk(data, false);

--- a/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
@@ -83,6 +83,7 @@ public class HttpClient implements Client {
     private static String URL_SEARCH;
     private static String URL_COUNT;
     private static String URL_ALIAS;
+    private static String URL_FIELD_MAPPING;
 
     @Autowired
     private Vertx vertx;
@@ -212,6 +213,7 @@ public class HttpClient implements Client {
         URL_SEARCH = urlPrefix + "/_search?ignore_unavailable=true";
         URL_COUNT = urlPrefix + "/_count?ignore_unavailable=true";
         URL_ALIAS = urlPrefix + "/_alias";
+        URL_FIELD_MAPPING = urlPrefix + "/_mapping/field/";
     }
 
     private List<ElasticsearchClient> clients() {
@@ -266,6 +268,18 @@ public class HttpClient implements Client {
             .get(URL_STATE_CLUSTER)
             .rxSend()
             .map(response -> mapper.readValue(response.bodyAsString(), Health.class));
+    }
+
+    @Override
+    public Single<List<String>> getFieldTypes(String indexName, String fieldName) {
+        return nextClient()
+            .getClient()
+            .get("/" + indexName + URL_FIELD_MAPPING + fieldName)
+            .rxSend()
+            .map(response -> {
+                JsonNode rootNode = mapper.readTree(response.bodyAsString());
+                return rootNode.findValuesAsText("type");
+            });
     }
 
     @Override

--- a/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
@@ -144,6 +144,32 @@ public class HttpClientTest {
         observer.assertNoValues();
     }
 
+    @Test
+    public void shouldGetFieldTypes() throws InterruptedException {
+        String template =
+            """
+        {
+          "mappings": {
+            "properties": {
+              "api-id": {
+                "type": "keyword"
+              }
+            }
+          },
+          "aliases": {}
+        }
+        """;
+        client.createIndexWithAlias("gravitee_field_types_test_1", template).test().await().assertNoErrors().assertComplete();
+        client.createIndexWithAlias("gravitee_field_types_test_2", template).test().await().assertNoErrors().assertComplete();
+
+        client
+            .getFieldTypes("gravitee_field_types_test_*", "api-id")
+            .test()
+            .await()
+            .assertNoErrors()
+            .assertValue(fieldTypes -> fieldTypes.size() == 2 && fieldTypes.stream().allMatch("keyword"::equals));
+    }
+
     @Configuration
     public static class TestConfig {
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5102

**Description**

Get index field types. It will allow us to create the good query when we update a mapping template

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.1.0-apim-5102-get-field-types-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/6.1.0-apim-5102-get-field-types-SNAPSHOT/gravitee-common-elasticsearch-6.1.0-apim-5102-get-field-types-SNAPSHOT.zip)
  <!-- Version placeholder end -->
