### PR TITLE
feat: add new bulk method with simple buffer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
     <name>Gravitee.io APIM - Elasticsearch - Common</name>
 
     <properties>
-        <gravitee-bom.version>6.0.10</gravitee-bom.version>
-        <gravitee-common.version>3.0.0</gravitee-common.version>
+        <gravitee-bom.version>8.1.19</gravitee-bom.version>
+        <gravitee-common.version>4.6.0</gravitee-common.version>
         <gravitee-reporter-api.version>1.26.0</gravitee-reporter-api.version>
         <freemarker.version>2.3.31</freemarker.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>

--- a/src/main/java/io/gravitee/elasticsearch/client/Client.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/Client.java
@@ -41,7 +41,18 @@ public interface Client {
         return bulk(data, false);
     }
 
-    Single<BulkResponse> bulk(List<Buffer> data, boolean forceRefresh);
+    default Single<BulkResponse> bulk(List<Buffer> data, boolean forceRefresh) {
+        Buffer payload = Buffer.buffer();
+        data.forEach(payload::appendBuffer);
+        return bulk(payload, forceRefresh);
+    }
+
+    default Single<BulkResponse> bulk(Buffer data) {
+        return bulk(data, false);
+    }
+
+    Single<BulkResponse> bulk(Buffer data, boolean forceRefresh);
+
     Completable putTemplate(String templateName, String template);
     Completable putIndexTemplate(String templateName, String template);
     Completable putPipeline(String templateName, String template);

--- a/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
@@ -283,10 +283,9 @@ public class HttpClient implements Client {
     }
 
     @Override
-    public Single<BulkResponse> bulk(final List<io.vertx.core.buffer.Buffer> data, boolean forceRefresh) {
+    public Single<BulkResponse> bulk(final io.vertx.core.buffer.Buffer data, boolean forceRefresh) {
         // Compact buffer
-        Buffer payload = Buffer.buffer();
-        data.forEach(buffer -> payload.appendBuffer(Buffer.newInstance(buffer)));
+        Buffer payload = Buffer.newInstance(data);
         String bulkURL = URL_BULK;
         if (forceRefresh) {
             bulkURL += "?refresh=true";


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-435

**Description**

Just adding a new method taking simple buffer for bulk fonction.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.2.0-archi-435-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/6.2.0-archi-435-SNAPSHOT/gravitee-common-elasticsearch-6.2.0-archi-435-SNAPSHOT.zip)
  <!-- Version placeholder end -->
