### PR TITLE
feat: add new EVENT_METRICS type

### DIFF
--- a/src/main/java/io/gravitee/elasticsearch/utils/Type.java
+++ b/src/main/java/io/gravitee/elasticsearch/utils/Type.java
@@ -27,7 +27,8 @@ public enum Type {
     V4_LOG("v4-log"),
     V4_METRICS("v4-metrics"),
     V4_MESSAGE_METRICS("v4-message-metrics"),
-    V4_MESSAGE_LOG("v4-message-log");
+    V4_MESSAGE_LOG("v4-message-log"),
+    EVENT_METRICS("event-metrics");
 
     private final String type;
 
@@ -40,6 +41,7 @@ public enum Type {
         V4_METRICS,
         V4_MESSAGE_LOG,
         V4_MESSAGE_METRICS,
+        EVENT_METRICS,
     };
 
     Type(final String type) {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-10024?atlOrigin=eyJpIjoiY2UxZWQwNTFhZDM1NDAxOTg1ZmZlYTQ2OTc1Y2NiMmYiLCJwIjoiaiJ9

**Description**

Add new EVENT_METRICS type. We need it to have the right index name into ES

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.3.0-APIM-10024-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/6.3.0-APIM-10024-SNAPSHOT/gravitee-common-elasticsearch-6.3.0-APIM-10024-SNAPSHOT.zip)
  <!-- Version placeholder end -->
