### PR TITLE
fix(client): add statusCode to ElasticsearchException

### DIFF
--- a/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
@@ -246,7 +246,8 @@ public class HttpClient implements Client {
                         response.statusCode() +
                         "] payload: [" +
                         response.bodyAsString() +
-                        "]"
+                        "]",
+                    response.statusCode()
                 );
             });
     }

--- a/src/main/java/io/gravitee/elasticsearch/exception/ElasticsearchException.java
+++ b/src/main/java/io/gravitee/elasticsearch/exception/ElasticsearchException.java
@@ -23,6 +23,8 @@ public class ElasticsearchException extends RuntimeException {
 
     private static final long serialVersionUID = -6926167778154953100L;
 
+    private Integer statusCode;
+
     public ElasticsearchException() {
         super();
     }
@@ -31,11 +33,20 @@ public class ElasticsearchException extends RuntimeException {
         super(message);
     }
 
+    public ElasticsearchException(String message, int statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
     public ElasticsearchException(String message, Throwable cause) {
         super(message, cause);
     }
 
     public ElasticsearchException(Throwable cause) {
         super(cause);
+    }
+
+    public Integer getStatusCode() {
+        return statusCode;
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12907

**Description**

Stop retrying indefinitely on Elasticsearch authentication errors. The reporter now fails fast with a clear error message on 401 (bad credentials) or 403 (insufficient permissions).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.2.2-fix-expose-status-code-in-exception-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/6.2.2-fix-expose-status-code-in-exception-SNAPSHOT/gravitee-common-elasticsearch-6.2.2-fix-expose-status-code-in-exception-SNAPSHOT.zip)
  <!-- Version placeholder end -->
