### PR TITLE
fix(client): add statusCode to ElasticsearchException

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.0
+    gravitee: gravitee-io/gravitee@4.16.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
@@ -243,7 +243,8 @@ public class HttpClient implements Client {
                     response.statusCode() +
                     "] payload: [" +
                     response.bodyAsString() +
-                    "]"
+                    "]",
+                    response.statusCode()
                 );
             });
     }

--- a/src/main/java/io/gravitee/elasticsearch/exception/ElasticsearchException.java
+++ b/src/main/java/io/gravitee/elasticsearch/exception/ElasticsearchException.java
@@ -23,6 +23,8 @@ public class ElasticsearchException extends RuntimeException {
 
     private static final long serialVersionUID = -6926167778154953100L;
 
+    private Integer statusCode;
+
     public ElasticsearchException() {
         super();
     }
@@ -31,11 +33,20 @@ public class ElasticsearchException extends RuntimeException {
         super(message);
     }
 
+    public ElasticsearchException(String message, int statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
     public ElasticsearchException(String message, Throwable cause) {
         super(message, cause);
     }
 
     public ElasticsearchException(Throwable cause) {
         super(cause);
+    }
+
+    public Integer getStatusCode() {
+        return statusCode;
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12907

**Description**

Stop retrying indefinitely on Elasticsearch authentication errors. The reporter now fails fast with a clear error message on 401 (bad credentials) or 403 (insufficient permissions).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `5.1.3-fix-expose-status-code-in-exception-5-1-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/5.1.3-fix-expose-status-code-in-exception-5-1-x-SNAPSHOT/gravitee-common-elasticsearch-5.1.3-fix-expose-status-code-in-exception-5-1-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
