### PR TITLE
Feat upgrade vertx5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.17.0
+    gravitee: gravitee-io/gravitee@5.5.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.5.1</version>
+        <version>23.5.0</version>
     </parent>
 
     <groupId>io.gravitee.elasticsearch</groupId>
@@ -34,8 +34,8 @@
 
     <properties>
         <gravitee-bom.version>8.3.47</gravitee-bom.version>
-        <gravitee-common.version>4.9.0</gravitee-common.version>
-        <gravitee-reporter-api.version>1.38.3</gravitee-reporter-api.version>
+        <gravitee-common.version>4.8.0</gravitee-common.version>
+        <gravitee-reporter-api.version>2.0.0</gravitee-reporter-api.version>
         <freemarker.version>2.3.34</freemarker.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <testcontainers.version>1.21.4</testcontainers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,11 @@
     <name>Gravitee.io APIM - Elasticsearch - Common</name>
 
     <properties>
-        <gravitee-bom.version>8.3.47</gravitee-bom.version>
-        <gravitee-common.version>4.8.0</gravitee-common.version>
+        <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
+        <gravitee-common.version>5.0.0-alpha.1</gravitee-common.version>
         <gravitee-reporter-api.version>2.0.0</gravitee-reporter-api.version>
         <freemarker.version>2.3.34</freemarker.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
-        <testcontainers.version>1.21.4</testcontainers.version>
     </properties>
 
     <dependencyManagement>
@@ -168,13 +167,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
@@ -35,12 +35,12 @@ import io.gravitee.elasticsearch.model.bulk.BulkResponse;
 import io.gravitee.elasticsearch.version.ElasticsearchInfo;
 import io.reactivex.rxjava3.core.*;
 import io.reactivex.rxjava3.functions.Function;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.ext.web.client.impl.WebClientInternal;
 import io.vertx.rxjava3.core.Vertx;
-import io.vertx.rxjava3.core.buffer.Buffer;
 import io.vertx.rxjava3.ext.web.client.WebClient;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -287,8 +287,7 @@ public class HttpClient implements Client {
     }
 
     @Override
-    public Single<BulkResponse> bulk(final io.vertx.core.buffer.Buffer data, boolean forceRefresh) {
-        Buffer payload = Buffer.newInstance(data);
+    public Single<BulkResponse> bulk(final Buffer data, boolean forceRefresh) {
         String bulkURL = URL_BULK;
         if (forceRefresh) {
             bulkURL += "?refresh=true";
@@ -300,7 +299,7 @@ public class HttpClient implements Client {
                 .getClient()
                 .post(url)
                 .putHeader(HttpHeaders.CONTENT_TYPE, "application/x-ndjson")
-                .rxSendBuffer(payload)
+                .rxSendBuffer(data)
                 .doOnError(throwable -> logger.error("Unable to send bulk data to Elasticsearch: {}", throwable.getMessage()))
                 .map(response -> {
                     if (response.statusCode() != HttpStatusCode.OK_200) {

--- a/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
@@ -163,31 +163,32 @@ public class HttpClient implements Client {
 
                     // Read configuration to authenticate calls to Elasticsearch (basic authentication only)
                     if (this.configuration.getUsername() != null) {
-                        this.authorizationHeader =
-                            this.initEncodedAuthorization(this.configuration.getUsername(), this.configuration.getPassword());
+                        this.authorizationHeader = this.initEncodedAuthorization(
+                            this.configuration.getUsername(),
+                            this.configuration.getPassword()
+                        );
                     }
 
                     ((WebClientInternal) httpClient.getDelegate()).addInterceptor(context -> {
-                            context
-                                .request()
-                                .timeout(configuration.getRequestTimeout())
-                                .putHeader(HttpHeaders.ACCEPT, CONTENT_TYPE)
-                                .putHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8.name());
+                        context
+                            .request()
+                            .timeout(configuration.getRequestTimeout())
+                            .putHeader(HttpHeaders.ACCEPT, CONTENT_TYPE)
+                            .putHeader(HttpHeaders.ACCEPT_CHARSET, StandardCharsets.UTF_8.name());
 
-                            // Basic authentication
-                            if (authorizationHeader != null) {
-                                context.request().putHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
-                            }
+                        // Basic authentication
+                        if (authorizationHeader != null) {
+                            context.request().putHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
+                        }
 
-                            context.next();
-                        });
+                        context.next();
+                    });
 
                     final ElasticsearchClient client = new ElasticsearchClient(httpClient);
                     httpClients.add(client);
 
                     // Health check
-                    Observable
-                        .interval(5, TimeUnit.SECONDS)
+                    Observable.interval(5, TimeUnit.SECONDS)
                         .flatMapSingle(
                             (Function<Long, SingleSource<ElasticsearchInfo>>) aLong -> getInfo(client).onErrorReturnItem(DUMMY_INFO)
                         )
@@ -238,10 +239,10 @@ public class HttpClient implements Client {
 
                 throw new ElasticsearchException(
                     "Unable to retrieve Elasticsearch information: status[" +
-                    response.statusCode() +
-                    "] payload: [" +
-                    response.bodyAsString() +
-                    "]",
+                        response.statusCode() +
+                        "] payload: [" +
+                        response.bodyAsString() +
+                        "]",
                     response.statusCode()
                 );
             });

--- a/src/main/java/io/gravitee/elasticsearch/index/AbstractIndexNameGenerator.java
+++ b/src/main/java/io/gravitee/elasticsearch/index/AbstractIndexNameGenerator.java
@@ -56,10 +56,14 @@ public abstract class AbstractIndexNameGenerator implements IndexNameGenerator {
         if (clusters == null || clusters.length == 0) {
             return getIndexPrefix(placeholder, type) + INDEX_DATE_SEPARATOR + ES_DAILY_INDICE.format(instant);
         } else {
-            return Stream
-                .of(clusters)
-                .map(cluster ->
-                    cluster + CLUSTER_SEPARATOR + getIndexPrefix(placeholder, type) + INDEX_DATE_SEPARATOR + ES_DAILY_INDICE.format(instant)
+            return Stream.of(clusters)
+                .map(
+                    cluster ->
+                        cluster +
+                        CLUSTER_SEPARATOR +
+                        getIndexPrefix(placeholder, type) +
+                        INDEX_DATE_SEPARATOR +
+                        ES_DAILY_INDICE.format(instant)
                 )
                 .collect(Collectors.joining(INDEX_SEPARATOR));
         }
@@ -68,20 +72,18 @@ public abstract class AbstractIndexNameGenerator implements IndexNameGenerator {
     @Override
     public String getIndexName(Map<String, String> placeholder, Type type, long from, long to, String[] clusters) {
         if (clusters == null || clusters.length == 0) {
-            return DateUtils
-                .rangedIndices(from, to)
+            return DateUtils.rangedIndices(from, to)
                 .stream()
                 .map(date -> getIndexPrefix(placeholder, type) + INDEX_DATE_SEPARATOR + date)
                 .collect(Collectors.joining(INDEX_SEPARATOR));
         } else {
-            return DateUtils
-                .rangedIndices(from, to)
+            return DateUtils.rangedIndices(from, to)
                 .stream()
                 .flatMap(
                     (Function<String, Stream<String>>) date ->
-                        Stream
-                            .of(clusters)
-                            .map(cluster -> cluster + CLUSTER_SEPARATOR + getIndexPrefix(placeholder, type) + INDEX_DATE_SEPARATOR + date)
+                        Stream.of(clusters).map(
+                            cluster -> cluster + CLUSTER_SEPARATOR + getIndexPrefix(placeholder, type) + INDEX_DATE_SEPARATOR + date
+                        )
                 )
                 .collect(Collectors.joining(INDEX_SEPARATOR));
         }
@@ -93,8 +95,7 @@ public abstract class AbstractIndexNameGenerator implements IndexNameGenerator {
         if (clusters == null || clusters.length == 0) {
             return getIndexPrefix(placeholder, type) + INDEX_DATE_SEPARATOR + suffixDay;
         } else {
-            return Stream
-                .of(clusters)
+            return Stream.of(clusters)
                 .map(cluster -> cluster + CLUSTER_SEPARATOR + getIndexPrefix(placeholder, type) + INDEX_DATE_SEPARATOR + suffixDay)
                 .collect(Collectors.joining(INDEX_SEPARATOR));
         }
@@ -105,8 +106,7 @@ public abstract class AbstractIndexNameGenerator implements IndexNameGenerator {
         if (clusters == null || clusters.length == 0) {
             return getIndexPrefix(placeholder, type) + INDEX_DATE_SEPARATOR + INDEX_WILDCARD;
         } else {
-            return Stream
-                .of(clusters)
+            return Stream.of(clusters)
                 .map(cluster -> cluster + CLUSTER_SEPARATOR + getIndexPrefix(placeholder, type) + INDEX_DATE_SEPARATOR + INDEX_WILDCARD)
                 .collect(Collectors.joining(INDEX_SEPARATOR));
         }

--- a/src/main/java/io/gravitee/elasticsearch/index/ILMIndexNameGenerator.java
+++ b/src/main/java/io/gravitee/elasticsearch/index/ILMIndexNameGenerator.java
@@ -61,8 +61,7 @@ public class ILMIndexNameGenerator extends AbstractIndexNameGenerator {
         if (clusters == null || clusters.length == 0) {
             return getIndexPrefix(parameters, type);
         } else {
-            return Stream
-                .of(clusters)
+            return Stream.of(clusters)
                 .map(cluster -> cluster + CLUSTER_SEPARATOR + getIndexPrefix(parameters, type))
                 .collect(Collectors.joining(INDEX_SEPARATOR));
         }

--- a/src/main/java/io/gravitee/elasticsearch/utils/DateUtils.java
+++ b/src/main/java/io/gravitee/elasticsearch/utils/DateUtils.java
@@ -91,7 +91,8 @@ public final class DateUtils {
             // if end date is the last day of the month then add the monthly indices
             if (stopYearMonth.atEndOfMonth().isEqual(stop)) {
                 indices.add(ES_MONTHLY_INDICE.format(stopYearMonth));
-            } else { // loop on daily indices until the end date of the last month
+            } else {
+                // loop on daily indices until the end date of the last month
                 LocalDate day = stopYearMonth.atDay(1);
                 while (day.isBefore(stop) || day.isEqual(stop)) {
                     indices.add(ES_DAILY_INDICE.format(day));

--- a/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
@@ -99,35 +99,34 @@ public class HttpClientTest {
 
     @Test
     public void shouldPutIndexTemplate() throws InterruptedException {
-        String template =
-            """
-                {
-                  "index_patterns": ["te*", "bar*"],
-                  "template": {
-                    "settings": {
-                      "number_of_shards": 1
-                    },
-                    "mappings": {
-                      "_source": {
-                        "enabled": true
-                      },
-                      "properties": {
-                        "host_name": {
-                          "type": "keyword"
-                        },
-                        "created_at": {
-                          "type": "date",
-                          "format": "EEE MMM dd HH:mm:ss Z yyyy"
-                        }
-                      }
-                    },
-                    "aliases": {
-                      "mydata": { }
-                    }
+        String template = """
+            {
+              "index_patterns": ["te*", "bar*"],
+              "template": {
+                "settings": {
+                  "number_of_shards": 1
+                },
+                "mappings": {
+                  "_source": {
+                    "enabled": true
                   },
-                  "priority": 500
+                  "properties": {
+                    "host_name": {
+                      "type": "keyword"
+                    },
+                    "created_at": {
+                      "type": "date",
+                      "format": "EEE MMM dd HH:mm:ss Z yyyy"
+                    }
+                  }
+                },
+                "aliases": {
+                  "mydata": { }
                 }
-                """;
+              },
+              "priority": 500
+            }
+            """;
 
         client.putIndexTemplate("gravitee_test_index_template", template).test().await().assertNoErrors().assertComplete();
     }
@@ -146,19 +145,18 @@ public class HttpClientTest {
 
     @Test
     public void shouldGetFieldTypes() throws InterruptedException {
-        String template =
-            """
-        {
-          "mappings": {
-            "properties": {
-              "api-id": {
-                "type": "keyword"
-              }
+        String template = """
+            {
+              "mappings": {
+                "properties": {
+                  "api-id": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "aliases": {}
             }
-          },
-          "aliases": {}
-        }
-        """;
+            """;
         client.createIndexWithAlias("gravitee_field_types_test_1", template).test().await().assertNoErrors().assertComplete();
         client.createIndexWithAlias("gravitee_field_types_test_2", template).test().await().assertNoErrors().assertComplete();
 

--- a/src/test/java/io/gravitee/elasticsearch/index/ILMIndexNameGeneratorTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/index/ILMIndexNameGeneratorTest.java
@@ -47,8 +47,9 @@ public class ILMIndexNameGeneratorTest {
         String[] clusters,
         String expectedIndexName
     ) {
-        assertThat(new ILMIndexNameGenerator(indexName).getIndexName(parameters, Type.REQUEST, 0, 0, clusters))
-            .isEqualTo(expectedIndexName);
+        assertThat(new ILMIndexNameGenerator(indexName).getIndexName(parameters, Type.REQUEST, 0, 0, clusters)).isEqualTo(
+            expectedIndexName
+        );
     }
 
     private static Stream<Arguments> shouldGenerateIndexNameWithPlaceholder() {
@@ -91,8 +92,13 @@ public class ILMIndexNameGeneratorTest {
 
     @Test
     void shouldGenerateIndexName_withClusters() {
-        String indexName = new ILMIndexNameGenerator("gravitee")
-            .getIndexName(parameters, Type.REQUEST, 0, 0, new String[] { "europe", "asia" });
+        String indexName = new ILMIndexNameGenerator("gravitee").getIndexName(
+            parameters,
+            Type.REQUEST,
+            0,
+            0,
+            new String[] { "europe", "asia" }
+        );
         assertThat(indexName).isEqualTo("europe:gravitee-request,asia:gravitee-request");
     }
 }

--- a/src/test/java/io/gravitee/elasticsearch/index/MultiTypeIndexNameGeneratorTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/index/MultiTypeIndexNameGeneratorTest.java
@@ -38,8 +38,9 @@ public class MultiTypeIndexNameGeneratorTest {
         String[] clusters,
         String expectedIndexName
     ) {
-        assertThat(new MultiTypeIndexNameGenerator(indexName).getIndexName(parameters, Type.REQUEST, 0, 0, clusters))
-            .isEqualTo(expectedIndexName);
+        assertThat(new MultiTypeIndexNameGenerator(indexName).getIndexName(parameters, Type.REQUEST, 0, 0, clusters)).isEqualTo(
+            expectedIndexName
+        );
     }
 
     private static Stream<Arguments> shouldGenerateIndexNameWithPlaceholder() {

--- a/src/test/java/io/gravitee/elasticsearch/index/PerTypeIndexNameGeneratorTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/index/PerTypeIndexNameGeneratorTest.java
@@ -38,8 +38,9 @@ public class PerTypeIndexNameGeneratorTest {
         String[] clusters,
         String expectedIndexName
     ) {
-        assertThat(new PerTypeIndexNameGenerator(indexName).getIndexName(parameters, Type.REQUEST, 0, 0, clusters))
-            .isEqualTo(expectedIndexName);
+        assertThat(new PerTypeIndexNameGenerator(indexName).getIndexName(parameters, Type.REQUEST, 0, 0, clusters)).isEqualTo(
+            expectedIndexName
+        );
     }
 
     private static Stream<Arguments> shouldGenerateIndexNameWithPlaceholder() {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

upgrade vertx5
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.0.0-feat-upgrade-vertx5-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/7.0.0-feat-upgrade-vertx5-SNAPSHOT/gravitee-common-elasticsearch-7.0.0-feat-upgrade-vertx5-SNAPSHOT.zip)
  <!-- Version placeholder end -->
