### PR TITLE
fix(client): resolve host from URI authority for underscore hostnames

### DIFF
--- a/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
+++ b/src/main/java/io/gravitee/elasticsearch/client/http/HttpClient.java
@@ -125,14 +125,26 @@ public class HttpClient implements Client {
                 initializePaths(URI.create(endpoints.get(0).getUrl()));
                 endpoints.forEach(endpoint -> {
                     final URI elasticEdpt = URI.create(endpoint.getUrl());
+                    String host = elasticEdpt.getHost();
+                    int port = elasticEdpt.getPort();
+                    if (host == null && elasticEdpt.getAuthority() != null) {
+                        String authority = elasticEdpt.getAuthority();
+                        int colonIdx = authority.lastIndexOf(':');
+                        if (colonIdx > 0) {
+                            host = authority.substring(0, colonIdx);
+                            try {
+                                port = Integer.parseInt(authority.substring(colonIdx + 1));
+                            } catch (NumberFormatException e) {
+                                logger.warn("Malformed port in Elasticsearch endpoint URL '{}'; using scheme default", endpoint.getUrl());
+                            }
+                        } else {
+                            host = authority;
+                        }
+                    }
 
-                    WebClientOptions options = new WebClientOptions()
-                        .setDefaultHost(elasticEdpt.getHost())
-                        .setDefaultPort(
-                            elasticEdpt.getPort() != -1
-                                ? elasticEdpt.getPort()
-                                : (HTTPS_SCHEME.equalsIgnoreCase(elasticEdpt.getScheme()) ? 443 : 80)
-                        );
+                    int schemeDefaultPort = HTTPS_SCHEME.equalsIgnoreCase(elasticEdpt.getScheme()) ? 443 : 80;
+                    int defaultPort = port != -1 ? port : schemeDefaultPort;
+                    WebClientOptions options = new WebClientOptions().setDefaultHost(host).setDefaultPort(defaultPort);
 
                     if (HTTPS_SCHEME.equalsIgnoreCase(elasticEdpt.getScheme())) {
                         options.setSsl(true).setTrustAll(true);

--- a/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
+++ b/src/test/java/io/gravitee/elasticsearch/client/HttpClientTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.elasticsearch.client;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.elasticsearch.client.http.HttpClient;
 import io.gravitee.elasticsearch.client.http.HttpClientConfiguration;
@@ -25,7 +27,11 @@ import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.vertx.rxjava3.core.Vertx;
+import java.net.URI;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -168,6 +174,50 @@ public class HttpClientTest {
             .await()
             .assertNoErrors()
             .assertValue(fieldTypes -> fieldTypes.size() == 2 && fieldTypes.stream().allMatch("keyword"::equals));
+    }
+
+    @Test
+    void uri_get_host_returns_null_for_underscore_hostname() {
+        URI uri = URI.create("http://elasticsearch_primary:9200");
+        assertThat(uri.getHost()).isNull();
+        assertThat(uri.getAuthority()).isEqualTo("elasticsearch_primary:9200");
+    }
+
+    @Nested
+    @ContextConfiguration(classes = { HttpClientTest.UnderscoreHostTests.Config.class })
+    class UnderscoreHostTests {
+
+        @Autowired
+        private Client client;
+
+        @Test
+        void initialize_with_underscore_hostname_does_not_throw_npe() throws InterruptedException {
+            TestObserver<ElasticsearchInfo> observer = client.getInfo().timeout(5, TimeUnit.SECONDS).test();
+            observer.await();
+            observer.assertError(e -> !(e instanceof NullPointerException));
+        }
+
+        @Configuration
+        static class Config {
+
+            @Bean
+            public Vertx vertx() {
+                return Vertx.vertx();
+            }
+
+            @Bean
+            public Client client(HttpClientConfiguration clientConfiguration) {
+                return new HttpClient(clientConfiguration);
+            }
+
+            @Bean
+            public HttpClientConfiguration configuration() {
+                HttpClientConfiguration cfg = new HttpClientConfiguration();
+                cfg.setEndpoints(List.of(new Endpoint("http://elasticsearch_primary:9200")));
+                cfg.setRequestTimeout(3_000L);
+                return cfg;
+            }
+        }
     }
 
     @Configuration


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-11916

**Description**

`java.net.URI.getHost()` returns `null` for hostnames containing underscores (e.g. Docker Compose service names like `elasticsearch_primary`). This `null` was passed directly to `WebClientOptions.setDefaultHost()`, causing `NullPointerException: Host cannot be null` at Vert.x request construction time on every ES call. The `retryWhen` caught the NPE and retried every 5 s indefinitely, so the Management API could not start when any configured Elasticsearch endpoint used an underscore in its hostname.

Root cause: RFC 3986 disallows underscores in hostnames; `java.net.URI` complies by returning `null` from `getHost()` while `getAuthority()` still carries the raw `hostname:port` string.

Fix: fall back to parsing host and port from `URI.getAuthority()` when `URI.getHost()` returns null.

**Additional context**

- Reported by ticket #14118, APIM 4.9.3
- Same fix applied to the `alpha` branch in a companion PR (targets 7.0.0-alpha.2 release)
- New test `HttpClientTest.UnderscoreHostTests` confirms `URI.getHost()` is null for underscore hostnames and that `getInfo()` fails with a connection error rather than NPE after the fix
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.6.1-apim-11916-6x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/elasticsearch/gravitee-common-elasticsearch/6.6.1-apim-11916-6x-SNAPSHOT/gravitee-common-elasticsearch-6.6.1-apim-11916-6x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
